### PR TITLE
Create synset CSVs for ease of use later

### DIFF
--- a/scripts/download_imagenet.py
+++ b/scripts/download_imagenet.py
@@ -160,7 +160,9 @@ def download_synset_lists():
     challenges, including the mapping from ID to word.
 
     This function downloads a tarred directory containing these lists to
-    DIRPATH_METADATA_LISTS, and then untars it to grab the relevant lists.
+    DIRPATH_METADATA_LISTS, and then untars it to grab the relevant lists. It
+    removes unused lists, and also translates the `det_synset_words.txt` and
+    `synset_words.txt` to CSVs for ease of use later.
     """
 
     fname_tarfile = os.path.basename(SYNSETS_URL)
@@ -180,6 +182,22 @@ def download_synset_lists():
     ]
     for fname in fnames_to_remove:
         os.remove(os.path.join(DIRPATH_METADATA_LISTS, fname))
+
+    fnames_synset_txts = ['det_synset_words.txt', 'synset_words.txt']
+    for fnames_synset_txt in fnames_synset_txts:
+        fpath_synset_txt = os.path.join(
+            DIRPATH_METADATA_LISTS, fnames_synset_txt
+        )
+        df_synset_text = pd.read_table(fpath_synset_txt, names=['text'])
+        # splits "n01440764 tench, Tinca tinca" =>
+        # ["n01440764", "tench, Tinca Tina"]
+        synsets, descriptions = df_synset_text['text'].str.split(' ', 1).str
+        synsets.name = 'synset'
+        descriptions.name = 'description'
+        df_synsets = pd.concat([synsets, descriptions], axis=1)
+
+        fpath_synset_csv = fpath_synset_txt.replace('txt', 'csv')
+        df_synsets.to_csv(fpath_synset_csv, index=False)
 
 
 def parse_args():


### PR DESCRIPTION
The synset lists come in `.txt` files. When read in using `pd.read_table`, it does not automatically parse these into two columns if the synset description (or any one of them) is longer than one word. This PR adds into the `download_imagenet.py` script the translation of those `.txt` files to `.csv` files for ease of use later. 