### PR TITLE
Add AlexNet network

### DIFF
--- a/dl_playground/networks/__init__.py
+++ b/dl_playground/networks/__init__.py
@@ -1,0 +1,1 @@
+"""Network architectures"""

--- a/dl_playground/networks/alexnet.py
+++ b/dl_playground/networks/alexnet.py
@@ -1,0 +1,102 @@
+"""AlexNet implementation
+
+Reference paper (using bitly link to save line length): https://bit.ly/2v4Aihl
+
+The main difference between this implementation and the paper is that it does
+not use any parallelization across GPUs.
+"""
+
+from tensorflow.keras.layers import (
+    Conv2D, Dense, Dropout, Flatten, Input, MaxPooling2D
+)
+
+
+class AlexNet(object):
+    """AlexNet model"""
+
+    def __init__(self, network_config):
+        """Init
+
+        network_config must contain the following keys:
+        - int or float height: height of the input to the network
+        - int or float width: width of the input to the network
+        - int or float n_channels: number of channels of the input
+        - int or float n_classes: number of classes in the output layer
+
+        :param network_config: specifies the configuration for the network
+        :type network_config: dict
+        """
+
+        self._validate_config(network_config)
+
+        self.height = network_config['height']
+        self.width = network_config['width']
+        self.n_channels = network_config['n_channels']
+        self.n_classes = network_config['n_classes']
+
+    @staticmethod
+    def _validate_config(network_config):
+        """Validate that the necessary keys are in the network_config
+
+        This raises a KeyError if there are required keys that are missing, and
+        otherwise does nothing.
+
+        :param network_config: specifies the configuration for the network
+        :type network_config: dict
+        """
+
+        required_keys = {'height', 'width', 'n_channels', 'n_classes'}
+        missing_keys = required_keys - set(network_config)
+
+        if missing_keys:
+            msg = (
+                '{} keys are missing from the network_config, but are '
+                'required in order to construct the model.'
+            ).format(missing_keys)
+            raise KeyError(msg)
+
+    def build(self):
+        """Return the inputs and outputs to instantiate a tf.keras.Model object
+
+        :return: inputs and outputs
+        :rtype: tuple(tf.Tensor)
+        """
+
+        inputs = Input(shape=(self.height, self.width, self.n_channels))
+
+        # === convolutional block 1 === #
+        layer = Conv2D(
+            filters=96, kernel_size=(11, 11), strides=(4, 4), padding='same',
+            activation='relu'
+        )(inputs)
+        layer = MaxPooling2D(pool_size=(3, 3), strides=(2, 2))(layer)
+
+        # === convolutional block 2 === #
+        layer = Conv2D(
+            filters=256, kernel_size=(5, 5), padding='same', activation='relu'
+        )(layer)
+        layer = MaxPooling2D(pool_size=(3, 3), strides=(2, 2))(layer)
+
+        # === convolutional blocks 3, 4, 5 === #
+        layer = Conv2D(
+            filters=384, kernel_size=(3, 3), padding='same', activation='relu'
+        )(layer)
+        layer = Conv2D(
+            filters=384, kernel_size=(3, 3), padding='same', activation='relu'
+        )(layer)
+        layer = Conv2D(
+            filters=256, kernel_size=(3, 3), padding='same', activation='relu'
+        )(layer)
+        layer = MaxPooling2D(pool_size=(3, 3), strides=(2, 2))(layer)
+
+        # === dense layers (2) === #
+        layer = Flatten()(layer)
+        layer = Dense(units=4096, activation='relu')(layer)
+        layer = Dropout(0.5)(layer)
+        layer = Dense(units=4096, activation='relu')(layer)
+        layer = Dropout(0.5)(layer)
+
+        # === output layer === #
+        outputs = Dense(units=self.n_classes, activation='softmax')(layer)
+
+        return inputs, outputs

--- a/tests/networks/test_alexnet.py
+++ b/tests/networks/test_alexnet.py
@@ -1,0 +1,104 @@
+"""Tests for networks.alexnet.py"""
+
+import pytest
+
+import numpy as np
+import tensorflow as tf
+
+from networks.alexnet import AlexNet
+
+
+class TestAlexNet(object):
+    """Tests for AlexNet"""
+
+    @pytest.fixture(scope='class')
+    def network_config(self):
+        """network_config object fixture
+
+        :return: network_config to be used with AlexNet
+        :rtype: dict
+        """
+
+        return {
+            'height': 227, 'width': 227, 'n_channels': 3, 'n_classes': 1000
+        }
+
+    def test_init(self, network_config):
+        """Test __init__ method
+
+        :param network_config: network_config object fixture
+        :type network_config: dict
+        """
+
+        alexnet = AlexNet(network_config)
+
+        assert alexnet.height == 227
+        assert alexnet.width == 227
+        assert alexnet.n_channels == 3
+        assert alexnet.n_classes == 1000
+
+    def test_validate_config(self, network_config):
+        """Test _validate_config method
+
+        :param network_config: network_config object fixture
+        :type network_config: dict
+        """
+
+        for network_key in network_config:
+            network_config_copy = network_config.copy()
+            del network_config_copy[network_key]
+
+            with pytest.raises(KeyError):
+                AlexNet(network_config_copy)
+
+    def test_build(self, network_config):
+        """Test build method
+
+        This tests a couple of things:
+        - The input and output layers are of the right type and shape
+        - The correct number of layers exist in the network, and of the
+          expected types
+        """
+
+        alexnet = AlexNet(network_config)
+        inputs, outputs = alexnet.build()
+
+        assert isinstance(inputs, tf.Tensor)
+        assert isinstance(outputs, tf.Tensor)
+        assert np.allclose(
+            inputs.get_shape().as_list()[1:], (227, 227, 3)
+        )
+        assert np.allclose(
+            outputs.get_shape().as_list()[1:], (1000)
+        )
+
+        model = tf.keras.Model(inputs, outputs)
+        layers_dict = {
+            'convolutional': {'expected_count': 5, 'count': 0},
+            'dense': {'expected_count': 3, 'count': 0},
+            'dropout': {'expected_count': 2, 'count': 0},
+            'flatten': {'expected_count': 1, 'count': 0},
+            'input': {'expected_count': 1, 'count': 0},
+            'max_pooling': {'expected_count': 3, 'count': 0},
+        }
+
+        for layer in model.layers:
+            if isinstance(layer, tf.keras.layers.Conv2D):
+                layer_type = 'convolutional'
+            elif isinstance(layer, tf.keras.layers.Dense):
+                layer_type = 'dense'
+            elif isinstance(layer, tf.keras.layers.Dropout):
+                layer_type = 'dropout'
+            elif isinstance(layer, tf.keras.layers.Flatten):
+                layer_type = 'flatten'
+            elif isinstance(layer, tf.keras.layers.InputLayer):
+                layer_type = 'input'
+            elif isinstance(layer, tf.keras.layers.MaxPooling2D):
+                layer_type = 'max_pooling'
+
+            layers_dict[layer_type]['count'] += 1
+
+        for layer_type in layers_dict:
+            expected_count = layers_dict[layer_type]['expected_count']
+            count = layers_dict[layer_type]['count']
+            assert expected_count == count


### PR DESCRIPTION
This PR adds a class that allows for construction of an `AlexNet` model via the `tf.keras.Model` class. Via the `AlexNet.build` method, the `inputs` and `outputs` are returned to create a `tf.keras.Model`. 