### PR TITLE
Add ImageNet Dataset

### DIFF
--- a/dl_playground/datasets/__init__.py
+++ b/dl_playground/datasets/__init__.py
@@ -1,0 +1,1 @@
+"""Datasets for training"""

--- a/dl_playground/datasets/imagenet.py
+++ b/dl_playground/datasets/imagenet.py
@@ -1,0 +1,88 @@
+"""DataSet for training a model on ImageNet"""
+
+import tensorflow as tf
+
+from datasets.ops import load_image, reshape_image_and_label
+
+
+class ImageNetDataSet(object):
+    """ImageNet dataset"""
+
+    def __init__(self, df_images, dataset_config):
+        """Init
+
+        dataset_config must contain the following keys:
+        - int or float height: height to reshape the images to
+        - int or float width: width to reshape the images to
+        - int or float batch_size: batch size to use for returning batches
+
+        :param df_images: holds the filepath to the input image ('fpath_image')
+         and the target label for the image ('label')
+        :type df_images: pandas.DataFrame
+        :param dataset_config: specifies the configuration of the dataset
+        :type dataset_config: dict
+        """
+
+        self._validate_config(dataset_config)
+
+        if set(df_images.columns) < {'fpath_image', 'label'}:
+            msg = (
+                'df_images must have an \'fpath_image\' and \'label\' '
+                'column, and only {} columns were given.'
+            ).format(df_images.columns)
+            raise KeyError(msg)
+
+        self.df_images = df_images
+
+        self.height = dataset_config['height']
+        self.width = dataset_config['width']
+        self.batch_size = dataset_config['batch_size']
+
+        self.num_parallel_calls = dataset_config.get('num_parallel_calls', 4)
+
+    @staticmethod
+    def _validate_config(dataset_config):
+        """Vaildate that the necessary keys are in the dataset_config
+
+        This raises a KeyError if there are required keys that are missing, and
+        otherwise does nothing.
+
+        :param dataset_config: specifies the configuration for the dataset
+        :type dataset_config: dict
+        """
+
+        required_keys = {'height', 'width', 'batch_size'}
+        missing_keys = required_keys - set(dataset_config)
+
+        if missing_keys:
+            msg = (
+                '{} keys are missing from the dataset_config, but are '
+                'required in order to construct the ImageNetDataSet.'
+            ).format(missing_keys)
+            raise KeyError(msg)
+
+    def get_infinite_iter(self):
+        """Return a tf.data.Dataset that iterates over the data indefinitely
+
+        :return: dataset that iterates over the data indefinitely
+        :rtype: tensorflow.data.Dataset
+        """
+
+        inputs = self.df_images['fpath_image'].values
+        outputs = self.df_images['label'].values
+        dataset = tf.data.Dataset.from_tensor_slices((inputs, outputs))
+        dataset = dataset.map(
+            load_image, num_parallel_calls=self.num_parallel_calls
+        )
+        dataset = dataset.shuffle(buffer_size=len(self.df_images))
+
+        target_image_shape = (self.height, self.width)
+        dataset = dataset.map(
+            lambda image, label: reshape_image_and_label(
+                image, label, target_image_shape, num_label_classes=1000
+            )
+        )
+        dataset = dataset.batch(self.batch_size)
+        dataset = dataset.repeat()
+
+        return dataset

--- a/dl_playground/datasets/ops.py
+++ b/dl_playground/datasets/ops.py
@@ -1,0 +1,52 @@
+"""Tensorflow operations for tf.Dataset objects"""
+
+import tensorflow as tf
+
+
+def load_image(fpath_image, label):
+    """Parse /decode and return the provided image
+
+    This op is intended to be used on a tf.Dataset object that is built around
+    image filepaths as the inputs and class labels as the targets, where the
+    image filepaths point to 2 dimensional RGB images (i.e. of shape (height,
+    width, 3)).
+
+    :param fpath_image: filepath to the input image to parse
+    :type fpath_image: str
+    :param label: class label associated with an image; this will simply be
+     passed through this function
+    :type label: tensorflow.Tensor
+    :return: tensorflow.Tensor objects holding the parsed / decoded image
+     along with the class label
+    :rtype: tuple
+    """
+
+    image_string = tf.read_file(fpath_image)
+    image = tf.image.decode_image(image_string, channels=3)
+
+    # set_shape because `tf.image.decode_image` does not set the shape, and if
+    # it isn't set then tf.image_resize_images won't work downstream
+    image.set_shape([None, None, None])
+    image = tf.image.convert_image_dtype(image, tf.float32)
+
+    return image, label
+
+
+def reshape_image_and_label(image, label, target_image_shape,
+                            num_label_classes):
+    """Reshape image to target_image_shape and one-hot encode label
+
+    :param image: image to reshape
+    :type image: tensorflow.Tensor
+    :param label: label to reshape
+    :type label: tensorflow.Tensor
+    :param target_image_shape: (height, width) to resize `image` to
+    :type target_image_shape: tuple or list
+    :param num_label_classes: `dense` argument to pass to `tensorflow.one_hot`
+    :type num_label_classes: int
+    """
+
+    image = tf.image.resize_images(image, target_image_shape)
+    label = tf.one_hot(label, num_label_classes)
+
+    return image, label

--- a/dl_playground/networks/alexnet.py
+++ b/dl_playground/networks/alexnet.py
@@ -51,7 +51,7 @@ class AlexNet(object):
         if missing_keys:
             msg = (
                 '{} keys are missing from the network_config, but are '
-                'required in order to construct the model.'
+                'required in order to construct the AlexNet model.'
             ).format(missing_keys)
             raise KeyError(msg)
 

--- a/tests/datasets/test_imagenet.py
+++ b/tests/datasets/test_imagenet.py
@@ -1,0 +1,185 @@
+"""Tests for datasets.imagenet.py"""
+
+import os
+import tempfile
+
+import imageio
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+import pytest
+
+from datasets.imagenet import ImageNetDataSet
+
+
+class TestImageNetDataSet(object):
+    """Tests for ImageNetDataSet"""
+
+    @pytest.fixture(scope='class')
+    def df_images(self):
+        """df_images object fixture
+
+        df_images will contain three rows with two columns, `fpath_image` and
+        `label`. Each `fpath_image` will point to a `numpy.ndarray` saved as
+        a JPEG, and the `label` will be equal to the index of that row (i.e.
+        0, 1, and 2).
+
+        :return: dataframe holding the filepath to the input image and the
+         target label for the image
+        :rtype: pandas.DataFrame
+        """
+
+        tempdir = tempfile.TemporaryDirectory()
+
+        rows = []
+        for idx in range(3):
+            height, width = np.random.randint(128, 600, 2)
+            num_channels = 3
+
+            input_image = np.random.random((height, width, num_channels))
+            fpath_image = os.path.join(tempdir.name, '{}.jpg'.format(idx))
+            imageio.imwrite(fpath_image, input_image)
+
+            rows.append({
+                'fpath_image': fpath_image, 'label': idx
+            })
+
+        df_images = pd.DataFrame(rows)
+        yield df_images
+
+    @pytest.fixture(scope='class')
+    def dataset_config(self):
+        """dataset_config object fixture
+
+        :return: dataset_config to be used for Imagenet training
+        :rtype: dict
+        """
+
+        return {
+            'height': 227, 'width': 227, 'batch_size': 256,
+        }
+
+    def _check_batches(self, batch_size, dataset_config, batches):
+        """Assert the size of the inputs and outputs of `batches`
+
+        :param dataset_config: dataset_config object fixture, with 'batch_size'
+         key equal to `batch_size`
+        :type dataset_config: dict
+        :param batch_size: size of the batch
+        :type batch_size: int
+        :param batches: batches of input and output pairs
+        :type batches: list[numpy.ndarray]
+        """
+
+        expected_image_shape = (
+            dataset_config['height'], dataset_config['width'], 3
+        )
+        expected_target_shape = (1000, )
+
+        for batch in batches:
+            assert batch[0].shape == (batch_size, ) + expected_image_shape
+            assert batch[1].shape == (batch_size, ) + expected_target_shape
+
+        assert not np.allclose(batches[0][0], batches[1][0])
+        assert not np.allclose(batches[0][1], batches[1][1])
+
+    def _get_batches(self, imagenet_dataset):
+        """Return two batches of data from the provided `imagenet_dataset`
+
+        :param imagenet_dataset: dataset to return batches from
+        :type imagenet_dataset: datasets.imagenet.ImageNetDataSet
+        :return: batches of data
+        :rtype: list[numpy.ndarray]
+        """
+
+        # call `tf.reset_default_graph` is necessary to ensure that the
+        # `tf.set_random_seed` call produces the same batching results
+        tf.reset_default_graph()
+
+        with tf.device('/cpu:0'):
+            # with such a small batch size (df_images is small), its important
+            # to set the random seed to actually ensure that the batches that
+            # come out are different
+            tf.set_random_seed(911)
+            dataset = imagenet_dataset.get_infinite_iter()
+            iterator = dataset.make_one_shot_iterator()
+            next_element_op = iterator.get_next()
+
+        with tf.Session() as sess:
+            # pull 2 batches to ensure that it loops back over the dataset
+            batches = []
+            for _ in range(2):
+                batch = sess.run(next_element_op)
+                batches.append(batch)
+
+        return batches
+
+    def test_init(self, df_images, dataset_config):
+        """Test __init__ method
+
+        This tests two things:
+        - All attributes are set correctly in the __init__
+        - A KeyError is raised if the fpath_image or label column is missing in
+          the df_images passed to the __init__ of the ImageNetDataSet
+
+        :param df_images : df_images object fixture
+        :type: pandas.DataFrame
+        :param dataset_config: dataset_config object fixture
+        :type dataset_config: dict
+        """
+
+        dataset = ImageNetDataSet(df_images, dataset_config)
+
+        assert df_images.equals(dataset.df_images)
+        assert dataset.height == 227
+        assert dataset.width == 227
+        assert dataset.batch_size == 256
+
+        assert dataset.num_parallel_calls == 4
+
+        for col in ['fpath_image', 'label']:
+            df_images_underspecified = df_images.drop(col, axis=1)
+
+            with pytest.raises(KeyError):
+                ImageNetDataSet(df_images_underspecified, dataset_config)
+
+    def test_validate_config(self, df_images, dataset_config):
+        """Test _validate_config method
+
+        :param df_images : df_images object fixture
+        :type: pandas.DataFrame
+        :param dataset_config: dataset_config object fixture
+        :type dataset_config: dict
+        """
+
+        for dataset_key in dataset_config:
+            dataset_config_copy = dataset_config.copy()
+            del dataset_config_copy[dataset_key]
+
+            with pytest.raises(KeyError):
+                ImageNetDataSet(df_images, dataset_config_copy)
+
+    def test_get_infinite_iter(self, df_images, dataset_config):
+        """Test get_infinite_iter method
+
+        :param df_images : df_images object fixture
+        :type: pandas.DataFrame
+        :param dataset_config: dataset_config object fixture
+        :type dataset_config: dict
+        """
+
+        # make a copy and adjust the batch_size for this test
+        dataset_config = dataset_config.copy()
+        batch_size = len(df_images)
+        dataset_config['batch_size'] = batch_size
+        imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
+
+        # call self._get_batches() twice to verify that using
+        # tf.set_random_seed ensures that the exact same batches are returned
+        batches1 = self._get_batches(imagenet_dataset)
+        self._check_batches(batch_size, dataset_config, batches1)
+        batches2 = self._get_batches(imagenet_dataset)
+
+        for batch_idx in range(len(batches1)):
+            assert np.allclose(batches1[batch_idx][0], batches2[batch_idx][0])
+            assert np.allclose(batches1[batch_idx][1], batches2[batch_idx][1])

--- a/tests/datasets/test_ops.py
+++ b/tests/datasets/test_ops.py
@@ -1,0 +1,73 @@
+"""Tests for datasets.ops.py"""
+
+import os
+import tempfile
+
+import imageio
+import numpy as np
+import tensorflow as tf
+
+from datasets.ops import load_image, reshape_image_and_label
+
+
+def test_load_image():
+    """Test load_image"""
+
+    tempdir = tempfile.TemporaryDirectory()
+
+    fpath_jpg = os.path.join(tempdir.name, 'image.jpg')
+    fpath_png = os.path.join(tempdir.name, 'image.png')
+
+    height, width = np.random.randint(128, 600, 2)
+    num_channels = 3
+    image = np.random.random((height, width, num_channels)).astype(np.uint8)
+    imageio.imwrite(fpath_jpg, image)
+    imageio.imwrite(fpath_png, image)
+
+    for fpath_image in [fpath_jpg, fpath_png]:
+        with tf.device('/cpu:0'):
+            loaded_image_op, label_op = load_image(
+                fpath_image, label=tf.constant(1)
+            )
+
+        with tf.Session() as sess:
+            loaded_image = sess.run(loaded_image_op)
+            label = sess.run(label_op)
+
+            assert np.allclose(loaded_image, image)
+            assert label == 1
+
+
+def test_reshape_image_and_label():
+    """Test reshape_image_and_label"""
+
+    height, width = np.random.randint(128, 600, 2)
+    num_channels = 3
+    image = np.random.random((height, width, num_channels))
+
+    image = tf.constant(image, dtype=tf.float32)
+    label = tf.constant(1, dtype=tf.uint8)
+
+    sess = tf.Session()
+    test_cases = [
+        {'target_image_shape': (64, 64), 'num_label_classes': 1},
+        {'target_image_shape': [28, 32], 'num_label_classes': 3},
+        {'target_image_shape': (128, 64), 'num_label_classes': 1000},
+        {'target_image_shape': [256, 256], 'num_label_classes': 10},
+    ]
+    for test_case in test_cases:
+        target_image_shape = test_case['target_image_shape']
+        num_label_classes = test_case['num_label_classes']
+        with tf.device('/cpu:0'):
+            image_reshaped_op, label_reshaped_op = reshape_image_and_label(
+                image, label, target_image_shape, num_label_classes
+            )
+
+        image_reshaped = sess.run(image_reshaped_op)
+        label_reshaped = sess.run(label_reshaped_op)
+
+        expected_image_shape = tuple(target_image_shape) + (3, )
+        assert np.allclose(image_reshaped.shape, expected_image_shape)
+        assert np.allclose(label_reshaped.shape, (num_label_classes,))
+
+    sess.close()


### PR DESCRIPTION
This creates an `ImageNetDataSet` class that is basically a wrapper around a number of `tf.data.Dataset` operations that are performed in order to return a dataset that can be passed to a `tf.keras.Model` object.