### PR TITLE
Add ImageNetTrainer class

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+"""Trainers for training models"""

--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -40,6 +40,15 @@ class ImageNetDataSet(object):
 
         self.num_parallel_calls = dataset_config.get('num_parallel_calls', 4)
 
+    def __len__(self):
+        """Return the size of the dataset
+
+        :return: size of the dataset
+        :rtype: int
+        """
+
+        return len(self.df_images)
+
     @staticmethod
     def _validate_config(dataset_config):
         """Vaildate that the necessary keys are in the dataset_config

--- a/dl_playground/trainers/imagenet_trainer.py
+++ b/dl_playground/trainers/imagenet_trainer.py
@@ -1,0 +1,83 @@
+"""Trainer for training a model on ImageNet"""
+
+from tensorflow.keras import Model
+
+
+class ImageNetTrainer(object):
+    """ImageNet Trainer"""
+
+    def __init__(self, trainer_config):
+        """Init
+
+        trainer_config must contain the following keys:
+        - str optimizer: optimizer to use when training the network
+        - str loss: loss function to use when training the network
+        - int batch_size: batch size to use during training
+        - int num_epochs: number of epochs to train for
+
+        :param trainer_config: specifies the configuration of the trainer
+        :type trainer_config: dict
+        """
+
+        self._validate_config(trainer_config)
+
+        self.optimizer = trainer_config['optimizer']
+        self.loss = trainer_config['loss']
+        self.batch_size = trainer_config['batch_size']
+        self.num_epochs = trainer_config['num_epochs']
+
+    @staticmethod
+    def _validate_config(trainer_config):
+        """Validate that the necessary keys are in the trainer_config
+
+        This raises a KeyError if there are required keys that are missing, and
+        otherwise does nothing.
+
+        :param trainer_config: specifies the configuration for the trainer
+        :type trainer_config: dict
+        """
+
+        required_keys = {'optimizer', 'loss', 'batch_size', 'num_epochs'}
+        missing_keys = required_keys - set(trainer_config)
+
+        if missing_keys:
+            msg = (
+                '{} keys are missing from the trainer_config, but are '
+                'required in order to use the ImageNetTrainer.'
+            ).format(missing_keys)
+            raise KeyError(msg)
+
+    def train(self, train_dataset, network, val_dataset=None):
+        """Train the network as specified via the __init__ parameters
+
+        :param train_dataset: dataset that iterates over the training data
+         indefinitely
+        :type train_dataset: tf.data.Dataset
+        :param network: network object to use for training
+        :type network: networks.alexnet.AlexNet
+        :param val_dataset: optional dataset that iterates over the validation
+         data indefinitly
+        :type val_dataset: tf.data.Dataset
+        """
+
+        inputs, outputs = network.build()
+        model = Model(inputs=inputs, outputs=outputs)
+        model.compile(
+            optimizer=self.optimizer, loss=self.loss
+        )
+
+        if val_dataset is not None:
+            validation_data = val_dataset.get_infinite_iter()
+            validation_steps = len(val_dataset) // self.batch_size
+        else:
+            validation_data = None
+            validation_steps = None
+
+        model.fit(
+            x=train_dataset.get_infinite_iter(),
+            steps_per_epoch=len(train_dataset) // self.batch_size,
+            epochs=self.num_epochs,
+            verbose=True,
+            validation_data=validation_data,
+            validation_steps=validation_steps
+        )

--- a/tests/datasets/test_imagenet_dataset.py
+++ b/tests/datasets/test_imagenet_dataset.py
@@ -143,6 +143,22 @@ class TestImageNetDataSet(object):
             with pytest.raises(KeyError):
                 ImageNetDataSet(df_images_underspecified, dataset_config)
 
+    def test_len(self, df_images, dataset_config):
+        """Test __len__ magic method
+
+        :param df_images : df_images object fixture
+        :type: pandas.DataFrame
+        :param dataset_config: dataset_config object fixture
+        :type dataset_config: dict
+        """
+
+        imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
+        assert len(imagenet_dataset) == 3
+
+        df_images2 = pd.concat([df_images] * 2)
+        imagenet_dataset = ImageNetDataSet(df_images2, dataset_config)
+        assert len(imagenet_dataset) == 6
+
     def test_validate_config(self, df_images, dataset_config):
         """Test _validate_config method
 

--- a/tests/trainers/test_imagenet_trainer.py
+++ b/tests/trainers/test_imagenet_trainer.py
@@ -1,0 +1,140 @@
+"""Tests for trainers.imagenet_trainer.py"""
+
+import os
+import tempfile
+
+import imageio
+import numpy as np
+import pandas as pd
+import pytest
+
+from datasets.imagenet_dataset import ImageNetDataSet
+from networks.alexnet import AlexNet
+from trainers.imagenet_trainer import ImageNetTrainer
+
+
+class TestImageNetTrainer(object):
+    """Tests for ImageNetTrainer"""
+
+    BATCH_SIZE = 3
+    HEIGHT = 227
+    WIDTH = 227
+
+    @pytest.fixture(scope='class')
+    def alexnet(self):
+        """alexnet object fixture
+
+        :return: alexnet model to use during training
+        :rtype: AlexNet
+        """
+
+        network_config = {
+            'height': self.HEIGHT, 'width': self.WIDTH,
+            'n_channels': 3, 'n_classes': 1000
+        }
+        return AlexNet(network_config)
+
+    @pytest.fixture(scope='class')
+    def df_images(self):
+        """df_images object fixture
+
+        This will act as a df_images to pass to an ImageNetDataSet. It will
+        contain three rows with two columns, `fpath_image` and `label`. Each
+        `fpath_image` will point to a `numpy.ndarray` saved as a JPEG, and the
+        `label` will be equal to the index of that row (i.e. 0, 1, and 2).
+
+        :return: dataframe holding the filepath to the input image and the
+        target label for the image
+        :rtype: pandas.DataFrame
+        """
+
+        tempdir = tempfile.TemporaryDirectory()
+
+        rows = []
+        for idx in range(self.BATCH_SIZE):
+            height, width = np.random.randint(128, 600, 2)
+            num_channels = 3
+
+            input_image = np.random.random((height, width, num_channels))
+            fpath_image = os.path.join(tempdir.name, '{}.jpg'.format(idx))
+            imageio.imwrite(fpath_image, input_image)
+
+            rows.append({
+                'fpath_image': fpath_image, 'label': idx
+            })
+
+        df_images = pd.DataFrame(rows)
+        yield df_images
+
+    @pytest.fixture(scope='class')
+    def imagenet_dataset(self, df_images):
+        """imagenet_dataset object fixture
+
+        :return: imagenet_dataset to be used in training
+        :rtype: ImageNetDataSet
+        """
+
+        dataset_config = {
+            'height': self.HEIGHT, 'width': self.WIDTH,
+            'batch_size': self.BATCH_SIZE
+        }
+        imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
+        return imagenet_dataset
+
+    @pytest.fixture(scope='class')
+    def trainer_config(self):
+        """trainer_config object fixture"""
+
+        return {
+            'optimizer': 'adam', 'loss': 'categorical_crossentropy',
+            'batch_size': self.BATCH_SIZE, 'num_epochs': 2
+        }
+
+    def test_init(self, trainer_config):
+        """Test __init__ method
+
+        :param trainer_config: trainer_config object fixture
+        :type trainer_config: dict
+        """
+
+        imagenet_trainer = ImageNetTrainer(trainer_config)
+
+        assert imagenet_trainer.optimizer == 'adam'
+        assert imagenet_trainer.loss == 'categorical_crossentropy'
+        assert imagenet_trainer.batch_size == self.BATCH_SIZE
+        assert imagenet_trainer.num_epochs == 2
+
+    def test_validate_config(self, trainer_config):
+        """Test _validate_config method
+
+        :param trainer_config: trainer_config object fixture
+        :type trainer_config: dict
+        """
+
+        for trainer_key in trainer_config:
+            trainer_config_copy = trainer_config.copy()
+            del trainer_config_copy[trainer_key]
+
+            with pytest.raises(KeyError):
+                ImageNetTrainer(trainer_config_copy)
+
+    def test_train(self, trainer_config, imagenet_dataset, alexnet):
+        """Test train method
+
+        :param trainer_config: trainer_config object fixture
+        :type trainer_config: dict
+        :param imagenet_dataset: imagenet_dataset object fixture
+        :type imagenet_dataset: datasets.imagenet_dataset.ImageNetDataSet
+        :param alexnet: alexnet object fixture
+        :type alexnet: networks.alexnet.AlexNet
+        """
+
+        imagenet_trainer = ImageNetTrainer(trainer_config)
+        imagenet_trainer.train(
+            train_dataset=imagenet_dataset, network=alexnet
+        )
+
+        imagenet_trainer.train(
+            train_dataset=imagenet_dataset, network=alexnet,
+            val_dataset=imagenet_dataset
+        )


### PR DESCRIPTION
This adds a class that can be used to train a model on ImageNet. In reality, it's a bit more general than that, and can train any specified network with any specified dataset. But, the only ones currently available are `AlexNet` and imagenet. 