### PR TITLE
Add centering op; update ImageNetDataSet with it

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -2,7 +2,7 @@
 
 import tensorflow as tf
 
-from datasets.ops import load_image, reshape_image_and_label
+from datasets.ops import load_image, center_image, reshape_image_and_label
 
 
 class ImageNetDataSet(object):
@@ -91,6 +91,7 @@ class ImageNetDataSet(object):
                 image, label, target_image_shape, num_label_classes=1000
             )
         )
+        dataset = dataset.map(center_image)
         dataset = dataset.batch(self.batch_size)
         dataset = dataset.repeat()
 

--- a/dl_playground/datasets/ops.py
+++ b/dl_playground/datasets/ops.py
@@ -3,6 +3,25 @@
 import tensorflow as tf
 
 
+def center_image(image, label):
+    """Apply tf.image.per_image_standardization to `image`
+
+    Note that `label` remains unchanged.
+
+    :param image: image to center
+    :type image: tensorflow.Tensor
+    :param label: label to pass through
+    :type label: tensorflow.Tensor
+    :return: tensorflow.Tensor objects holding the centered image and
+     unmodified label
+    :rtype: tuple(tensorflow.Tensor)
+    """
+
+    image = tf.image.per_image_standardization(image)
+
+    return image, label
+
+
 def load_image(fpath_image, label):
     """Parse /decode and return the provided image
 
@@ -18,7 +37,7 @@ def load_image(fpath_image, label):
     :type label: tensorflow.Tensor
     :return: tensorflow.Tensor objects holding the parsed / decoded image
      along with the class label
-    :rtype: tuple
+    :rtype: tuple(tensorflow.Tensor)
     """
 
     image_string = tf.read_file(fpath_image)
@@ -44,6 +63,8 @@ def reshape_image_and_label(image, label, target_image_shape,
     :type target_image_shape: tuple or list
     :param num_label_classes: `dense` argument to pass to `tensorflow.one_hot`
     :type num_label_classes: int
+    :return: tensorflow.Tensor objects holding the reshaped image and label
+    :rtype: tuple(tensorflow.Tensor)
     """
 
     image = tf.image.resize_images(image, target_image_shape)

--- a/tests/datasets/test_imagenet_dataset.py
+++ b/tests/datasets/test_imagenet_dataset.py
@@ -196,6 +196,13 @@ class TestImageNetDataSet(object):
         self._check_batches(batch_size, dataset_config, batches1)
         batches2 = self._get_batches(imagenet_dataset)
 
+        # assert that the batches are the exact same
         for batch_idx in range(len(batches1)):
             assert np.allclose(batches1[batch_idx][0], batches2[batch_idx][0])
             assert np.allclose(batches1[batch_idx][1], batches2[batch_idx][1])
+
+        # check that each individual input is centered
+        images = batches1[0][0]
+        for image in images:
+            assert np.allclose(image.mean(), 0, atol=1e-4)
+            assert np.allclose(image.std(), 1, atol=1e-4)

--- a/tests/datasets/test_ops.py
+++ b/tests/datasets/test_ops.py
@@ -2,12 +2,58 @@
 
 import os
 import tempfile
+import pytest
 
 import imageio
 import numpy as np
 import tensorflow as tf
 
-from datasets.ops import load_image, reshape_image_and_label
+from datasets.ops import center_image, load_image, reshape_image_and_label
+
+
+@pytest.fixture(scope='module')
+def image():
+    """Return a tensorflow.Tensor holding an image object fixture
+
+    :return: tensorflow.Tensor holding an image to use in tests
+    :rtype: tensorflow.Tensor
+    """
+
+    height, width = np.random.randint(128, 600, 2)
+    num_channels = 3
+    image = np.random.random((height, width, num_channels))
+
+    return image
+
+
+@pytest.fixture(scope='module')
+def label():
+    """Return a tensorflow.Tensor holding an label object fixture
+
+    :return: tensorflow.Tensor holding a label to use in tests
+    :rtype: tensorflow.Tensor
+    """
+
+    label = tf.constant(1, dtype=tf.uint8)
+    return label
+
+
+def test_center_image(image, label):
+    """Test center_image
+
+    :param image: module wide image object fixture
+    :type image: tensorflow.Tensor
+    :param lable: module wide label object fixture
+    :type label: tensorflow.Tensor
+    """
+
+    image_centered_op, label = center_image(image, label)
+
+    with tf.Session() as sess:
+        image_centered = sess.run(image_centered_op)
+
+        assert np.allclose(image_centered.mean(), 0, atol=1e-4)
+        assert np.allclose(image_centered.std(), 1, atol=1e-4)
 
 
 def test_load_image():
@@ -38,15 +84,14 @@ def test_load_image():
             assert label == 1
 
 
-def test_reshape_image_and_label():
-    """Test reshape_image_and_label"""
+def test_reshape_image_and_label(image, label):
+    """Test reshape_image_and_label
 
-    height, width = np.random.randint(128, 600, 2)
-    num_channels = 3
-    image = np.random.random((height, width, num_channels))
-
-    image = tf.constant(image, dtype=tf.float32)
-    label = tf.constant(1, dtype=tf.uint8)
+    :param image: module wide image object fixture
+    :type image: tensorflow.Tensor
+    :param lable: module wide label object fixture
+    :type label: tensorflow.Tensor
+    """
 
     sess = tf.Session()
     test_cases = [


### PR DESCRIPTION
This PR adds a `center_image` op that takes in an image and centers it to have zero mean and unit norm. It also updates the `ImageNetDataSet` class to make use of it to normalize the inputs before they are output by the dataset. 