### PR TITLE
Alter ImageNet download scripts to differentiate download source

### DIFF
--- a/scripts/create_imagenet_set_splits.py
+++ b/scripts/create_imagenet_set_splits.py
@@ -9,7 +9,9 @@ from sklearn.model_selection import train_test_split
 from utils import dev_env
 
 DIRPATH_DATA = dev_env.get('imagenet', 'dirpath_data')
-DIRPATH_METADATA_LISTS = os.path.join(DIRPATH_DATA, 'metadata_lists')
+DIRPATH_METADATA_LISTS = os.path.join(
+    DIRPATH_DATA, 'from_urls', 'metadata_lists'
+)
 
 FPATH_BAD_FILES_TXT = os.path.join(DIRPATH_METADATA_LISTS, 'bad_files.txt')
 FPATH_DF_FPATHS_IMAGES = os.path.join(
@@ -20,7 +22,7 @@ FPATH_UNLOADABLE_FILES_CSV = os.path.join(
 )
 
 FPATH_SYNSET_WORDS = os.path.join(
-    DIRPATH_METADATA_LISTS, 'synset_words.txt'
+    DIRPATH_DATA, 'synset_lists', 'synset_words.txt'
 )
 
 

--- a/scripts/download_imagenet.py
+++ b/scripts/download_imagenet.py
@@ -15,9 +15,11 @@ from tqdm import tqdm
 from utils import dev_env
 
 DIRPATH_DATA = dev_env.get('imagenet', 'dirpath_data')
-DIRPATH_BBOX_XMLS = os.path.join(DIRPATH_DATA, 'bbox_xmls')
-DIRPATH_IMAGES = os.path.join(DIRPATH_DATA, 'images')
-DIRPATH_METADATA_LISTS = os.path.join(DIRPATH_DATA, 'metadata_lists')
+DIRPATH_BBOX_XMLS = os.path.join(DIRPATH_DATA, 'from_urls', 'bbox_xmls')
+DIRPATH_IMAGES = os.path.join(DIRPATH_DATA, 'from_urls', 'images')
+DIRPATH_METADATA_LISTS = os.path.join(
+    DIRPATH_DATA, 'from_urls', 'metadata_lists'
+)
 FPATH_FAILED_URLS_CSV = os.path.join(
     DIRPATH_METADATA_LISTS, 'failed_download_urls.csv'
 )

--- a/scripts/download_imagenet.py
+++ b/scripts/download_imagenet.py
@@ -23,7 +23,6 @@ FPATH_FAILED_URLS_CSV = os.path.join(
 )
 
 BBOX_XMLS_URL = 'http://www.image-net.org/Annotation/Annotation.tar.gz'
-SYNSETS_URL = 'http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz'
 URLS_LIST_URL = (
     'http://image-net.org/imagenet_data/urls/imagenet_fall11_urls.tgz'
 )
@@ -153,53 +152,6 @@ def download_image_urls_list():
     return fpath_urls_txt
 
 
-def download_synset_lists():
-    """Download relevant synset lists
-
-    These lists include the synset IDs for the classification and detection
-    challenges, including the mapping from ID to word.
-
-    This function downloads a tarred directory containing these lists to
-    DIRPATH_METADATA_LISTS, and then untars it to grab the relevant lists. It
-    removes unused lists, and also translates the `det_synset_words.txt` and
-    `synset_words.txt` to CSVs for ease of use later.
-    """
-
-    fname_tarfile = os.path.basename(SYNSETS_URL)
-    fpath_tarfile = os.path.join(DIRPATH_METADATA_LISTS, fname_tarfile)
-
-    cmd = 'wget {} -P {}'.format(SYNSETS_URL, DIRPATH_METADATA_LISTS)
-    process = subprocess.Popen(cmd.split())
-    process.communicate()
-
-    cmd = 'tar -xvf {} -C {}'.format(fpath_tarfile, DIRPATH_METADATA_LISTS)
-    process = subprocess.Popen(cmd.split())
-    process.communicate()
-
-    fnames_to_remove = [
-        'imagenet.bet.pickle', 'imagenet_mean.binaryproto', 'synsets.txt',
-        'train.txt', 'val.txt', 'test.txt'
-    ]
-    for fname in fnames_to_remove:
-        os.remove(os.path.join(DIRPATH_METADATA_LISTS, fname))
-
-    fnames_synset_txts = ['det_synset_words.txt', 'synset_words.txt']
-    for fnames_synset_txt in fnames_synset_txts:
-        fpath_synset_txt = os.path.join(
-            DIRPATH_METADATA_LISTS, fnames_synset_txt
-        )
-        df_synset_text = pd.read_table(fpath_synset_txt, names=['text'])
-        # splits "n01440764 tench, Tinca tinca" =>
-        # ["n01440764", "tench, Tinca Tina"]
-        synsets, descriptions = df_synset_text['text'].str.split(' ', 1).str
-        synsets.name = 'synset'
-        descriptions.name = 'description'
-        df_synsets = pd.concat([synsets, descriptions], axis=1)
-
-        fpath_synset_csv = fpath_synset_txt.replace('txt', 'csv')
-        df_synsets.to_csv(fpath_synset_csv, index=False)
-
-
 def parse_args():
     """Parse command line arguments"""
 
@@ -234,7 +186,6 @@ def main():
             os.makedirs(dirpath)
 
     download_bbox_xmls()
-    download_synset_lists()
 
     if args.from_failed_urls:
         fpath_urls = FPATH_FAILED_URLS_CSV

--- a/scripts/download_synset_lists.py
+++ b/scripts/download_synset_lists.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python
+"""Download ImageNet images from the fall11_urls"""
+
+import os
+import subprocess
+
+import pandas as pd
+
+from utils import dev_env
+
+DIRPATH_DATA = dev_env.get('imagenet', 'dirpath_data')
+DIRPATH_SYNSET_LISTS = os.path.join(DIRPATH_DATA, 'synset_lists')
+SYNSETS_URL = 'http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz'
+
+
+def download_synset_lists():
+    """Download relevant synset lists
+
+    These lists include the synset IDs for the classification and detection
+    challenges, including the mapping from ID to word.
+
+    This function downloads a tarred directory containing these lists to
+    DIRPATH_SYNSET_LISTS, and then untars it to grab the relevant lists. It
+    removes unused lists, and also translates the `det_synset_words.txt` and
+    `synset_words.txt` to CSVs for ease of use later.
+    """
+
+    fname_tarfile = os.path.basename(SYNSETS_URL)
+    fpath_tarfile = os.path.join(DIRPATH_SYNSET_LISTS, fname_tarfile)
+
+    cmd = 'wget {} -P {}'.format(SYNSETS_URL, DIRPATH_SYNSET_LISTS)
+    process = subprocess.Popen(cmd.split())
+    process.communicate()
+
+    cmd = 'tar -xvf {} -C {}'.format(fpath_tarfile, DIRPATH_SYNSET_LISTS)
+    process = subprocess.Popen(cmd.split())
+    process.communicate()
+
+    fnames_to_remove = [
+        'imagenet.bet.pickle', 'imagenet_mean.binaryproto', 'synsets.txt',
+        'train.txt', 'val.txt', 'test.txt'
+    ]
+    for fname in fnames_to_remove:
+        os.remove(os.path.join(DIRPATH_SYNSET_LISTS, fname))
+
+    fnames_synset_txts = ['det_synset_words.txt', 'synset_words.txt']
+    for fnames_synset_txt in fnames_synset_txts:
+        fpath_synset_txt = os.path.join(
+            DIRPATH_SYNSET_LISTS, fnames_synset_txt
+        )
+        df_synset_text = pd.read_table(fpath_synset_txt, names=['text'])
+        # splits "n01440764 tench, Tinca tinca" =>
+        # ["n01440764", "tench, Tinca Tina"]
+        synsets, descriptions = df_synset_text['text'].str.split(' ', 1).str
+        synsets.name = 'synset'
+        descriptions.name = 'description'
+        df_synsets = pd.concat([synsets, descriptions], axis=1)
+
+        fpath_synset_csv = fpath_synset_txt.replace('txt', 'csv')
+        df_synsets.to_csv(fpath_synset_csv, index=False)
+
+
+def main():
+    """Main logic"""
+
+    download_synset_lists()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/download_synset_lists.py
+++ b/scripts/download_synset_lists.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Download ImageNet images from the fall11_urls"""
+"""Download mappings from synset IDs to synset names"""
 
 import os
 import subprocess

--- a/scripts/find_unloadable_imagenet_images.py
+++ b/scripts/find_unloadable_imagenet_images.py
@@ -22,8 +22,11 @@ from utils import dev_env
 
 
 DIRPATH_DATA = dev_env.get('imagenet', 'dirpath_data')
-DIRPATH_IMAGES = os.path.join(DIRPATH_DATA, 'images')
-DIRPATH_METADATA_LISTS = os.path.join(DIRPATH_DATA, 'metadata_lists')
+DIRPATH_IMAGES = os.path.join(DIRPATH_DATA, 'from_urls', 'images')
+DIRPATH_METADATA_LISTS = os.path.join(
+    DIRPATH_DATA, 'from_urls', 'metadata_lists'
+)
+DIRPATH_SYNSET_LISTS = os.path.join(DIRPATH_DATA, 'synset_lists')
 FPATH_DF_FPATHS_IMAGES = os.path.join(
     DIRPATH_METADATA_LISTS, 'df_fpaths_images.csv'
 )
@@ -149,7 +152,7 @@ def main():
     args = parse_args()
 
     fpath_synsets_csv = os.path.join(
-        DIRPATH_METADATA_LISTS, 'synset_words.csv'
+        DIRPATH_SYNSET_LISTS, 'synset_words.csv'
     )
     df_synsets = pd.read_csv(fpath_synsets_csv)
     df_fpath_images = get_fpaths_images(df_synsets['synset'])


### PR DESCRIPTION
Currently, the scripts for downloading ImageNet download the images from the individual image URLs. Since it's also possible to download ImageNet as a tarfile with requested access, the directory structure (and corresponding code) have been altered to make it more clear of the download source. The current scripts have been updated, and additional scripts that process the data downloaded from the access links will be added in future PRs. 