### PR TITLE
Update `plot_classifications` script to be more general

### DIFF
--- a/scripts/imagenet/from_access_links/create_set_splits.py
+++ b/scripts/imagenet/from_access_links/create_set_splits.py
@@ -88,6 +88,7 @@ def add_train_set_labels(df_fpaths_images, df_synsets_mapping):
 
     return df_fpaths_images
 
+
 def add_val_set_labels(df_fpaths_images, df_synsets_mapping):
     """Merge on the synset labels for each image in the validation set
 


### PR DESCRIPTION
This updates the plotting script for ImageNet object classification to be a bit more general, and allow for passing in any dataframe (train or val) and having the images saved a specified directory. Prior to this PR, it was working with a fixed training dataframe and saving to a fixed directory. 