### PR TITLE
Add script for downloading the DeepLesion data

### DIFF
--- a/dev_env.ini
+++ b/dev_env.ini
@@ -1,2 +1,5 @@
 [imagenet]
 dirpath_data=/data/imagenet
+
+[deep_lesion]
+dirpath_data=/data/deep_lesion

--- a/scripts/deep_lesion/download.py
+++ b/scripts/deep_lesion/download.py
@@ -1,0 +1,139 @@
+#! /usr/bin/env python
+"""Download the DeepLesion dataset
+
+Note that this does not download the metadata CSV that is provided with the
+data (`DL_info.csv`), as there wasn't an explicit link available for that. This
+must be downloaded manually from [1].
+
+[1] Dropbox source: https://nihcc.app.box.com/v/DeepLesion
+[2] Background information (bitly link for brevity): https://bit.ly/2uJutbH
+
+Reference script: `batch_download_zips.py` in [1]
+"""
+
+import os
+import subprocess
+from urllib import request
+
+from tqdm import tqdm
+
+from utils import dev_env
+
+
+DIRPATH_DATA = dev_env.get('deep_lesion', 'dirpath_data')
+DIRPATH_ZIPS = os.path.join(DIRPATH_DATA, 'image_zipfiles')
+DIRPATH_IMAGES = os.path.join(DIRPATH_DATA, 'images')
+
+ZIPFILE_URLS = [
+    'https://nihcc.box.com/shared/static/sp5y2k799v4x1x77f7w1aqp26uyfq7qz.zip',
+    'https://nihcc.box.com/shared/static/l9e1ys5e48qq8s409ua3uv6uwuko0y5c.zip',
+    'https://nihcc.box.com/shared/static/48jotosvbrw0rlke4u88tzadmabcp72r.zip',
+    'https://nihcc.box.com/shared/static/xa3rjr6nzej6yfgzj9z6hf97ljpq1wkm.zip',
+    'https://nihcc.box.com/shared/static/58ix4lxaadjxvjzq4am5ehpzhdvzl7os.zip',
+    'https://nihcc.box.com/shared/static/cfouy1al16n0linxqt504n3macomhdj8.zip',
+    'https://nihcc.box.com/shared/static/z84jjstqfrhhlr7jikwsvcdutl7jnk78.zip',
+    'https://nihcc.box.com/shared/static/6viu9bqirhjjz34xhd1nttcqurez8654.zip',
+    'https://nihcc.box.com/shared/static/9ii2xb6z7869khz9xxrwcx1393a05610.zip',
+    'https://nihcc.box.com/shared/static/2c7y53eees3a3vdls5preayjaf0mc3bn.zip',
+
+    'https://nihcc.box.com/shared/static/2zsqpzru46wsp0f99eaag5yiad42iezz.zip',
+    'https://nihcc.box.com/shared/static/8v8kfhgyngceiu6cr4sq1o8yftu8162m.zip',
+    'https://nihcc.box.com/shared/static/jl8ic5cq84e1ijy6z8h52mhnzfqj36q6.zip',
+    'https://nihcc.box.com/shared/static/un990ghdh14hp0k7zm8m4qkqrbc0qfu5.zip',
+    'https://nihcc.box.com/shared/static/kxvbvri827o1ssl7l4ji1fngfe0pbt4p.zip',
+    'https://nihcc.box.com/shared/static/h1jhw1bee3c08pgk537j02q6ue2brxmb.zip',
+    'https://nihcc.box.com/shared/static/78hamrdfzjzevrxqfr95h1jqzdqndi19.zip',
+    'https://nihcc.box.com/shared/static/kca6qlkgejyxtsgjgvyoku3z745wbgkc.zip',
+    'https://nihcc.box.com/shared/static/e8yrtq31g0d8yhjrl6kjplffbsxoc5aw.zip',
+    'https://nihcc.box.com/shared/static/vomu8feie1qembrsfy2yaq36cimvymj8.zip',
+
+    'https://nihcc.box.com/shared/static/ecwyyx47p2jd621wt5c5tc92dselz9nx.zip',
+    'https://nihcc.box.com/shared/static/fbnafa8rj00y0b5tq05wld0vbgvxnbpe.zip',
+    'https://nihcc.box.com/shared/static/50v75duviqrhaj1h7a1v3gm6iv9d58en.zip',
+    'https://nihcc.box.com/shared/static/oylbi4bmcnr2o65id2v9rfnqp16l3hp0.zip',
+    'https://nihcc.box.com/shared/static/mw15sn09vriv3f1lrlnh3plz7pxt4hoo.zip',
+    'https://nihcc.box.com/shared/static/zi68hd5o6dajgimnw5fiu7sh63kah5sd.zip',
+    'https://nihcc.box.com/shared/static/3yiszde3vlklv4xoj1m7k0syqo3yy5ec.zip',
+    'https://nihcc.box.com/shared/static/w2v86eshepbix9u3813m70d8zqe735xq.zip',
+    'https://nihcc.box.com/shared/static/0cf5w11yvecfq34sd09qol5atzk1a4ql.zip',
+    'https://nihcc.box.com/shared/static/275en88yybbvzf7hhsbl6d7kghfxfshi.zip',
+
+    'https://nihcc.box.com/shared/static/l52tpmmkgjlfa065ow8czhivhu5vx27n.zip',
+    'https://nihcc.box.com/shared/static/p89awvi7nj0yov1l2o9hzi5l3q183lqe.zip',
+    'https://nihcc.box.com/shared/static/or9m7tqbrayvtuppsm4epwsl9rog94o8.zip',
+    'https://nihcc.box.com/shared/static/vuac680472w3r7i859b0ng7fcxf71wev.zip',
+    'https://nihcc.box.com/shared/static/pllix2czjvoykgbd8syzq9gq5wkofps6.zip',
+    'https://nihcc.box.com/shared/static/2dn2kipkkya5zuusll4jlyil3cqzboyk.zip',
+    'https://nihcc.box.com/shared/static/peva7rpx9lww6zgpd0n8olpo3b2n05ft.zip',
+    'https://nihcc.box.com/shared/static/2fda8akx3r3mhkts4v6mg3si7dipr7rg.zip',
+    'https://nihcc.box.com/shared/static/ijd3kwljgpgynfwj0vhj5j5aurzjpwxp.zip',
+    'https://nihcc.box.com/shared/static/nc6rwjixplkc5cx983mng9mwe99j8oa2.zip',
+
+    'https://nihcc.box.com/shared/static/rhnfkwctdcb6y92gn7u98pept6qjfaud.zip',
+    'https://nihcc.box.com/shared/static/7315e79xqm72osa4869oqkb2o0wayz6k.zip',
+    'https://nihcc.box.com/shared/static/4nbwf4j9ejhm2ozv8mz3x9jcji6knhhk.zip',
+    'https://nihcc.box.com/shared/static/1lhhx2uc7w14bt70de0bzcja199k62vn.zip',
+    'https://nihcc.box.com/shared/static/guho09wmfnlpmg64npz78m4jg5oxqnbo.zip',
+    'https://nihcc.box.com/shared/static/epu016ga5dh01s9ynlbioyjbi2dua02x.zip',
+    'https://nihcc.box.com/shared/static/b4ebv95vpr55jqghf6bthg92vktocdkg.zip',
+    'https://nihcc.box.com/shared/static/byl9pk2y727wpvk0pju4ls4oomz9du6t.zip',
+    'https://nihcc.box.com/shared/static/kisfbpualo24dhby243nuyfr8bszkqg1.zip',
+    'https://nihcc.box.com/shared/static/rs1s5ouk4l3icu1n6vyf63r2uhmnv6wz.zip',
+
+    'https://nihcc.box.com/shared/static/7tvrneuqt4eq4q1d7lj0fnafn15hu9oj.zip',
+    'https://nihcc.box.com/shared/static/gjo530t0dgeci3hizcfdvubr2n3mzmtu.zip',
+    'https://nihcc.box.com/shared/static/7x4pvrdu0lhazj83sdee7nr0zj0s1t0v.zip',
+    'https://nihcc.box.com/shared/static/z7s2zzdtxe696rlo16cqf5pxahpl8dup.zip',
+    'https://nihcc.box.com/shared/static/shr998yp51gf2y5jj7jqxz2ht8lcbril.zip',
+    'https://nihcc.box.com/shared/static/kqg4peb9j53ljhrxe3l3zrj4ac6xogif.zip'
+]
+
+
+def download_zips():
+    """Download all image zipfiles in ZIPFILE_URLS to DIRPATH_ZIPS
+
+    :return: filepaths to the downloaded zips
+    :type: list[str]
+    """
+
+    fpaths_zipfiles = []
+    for zipfile_url in tqdm(ZIPFILE_URLS, total=len(ZIPFILE_URLS)):
+        fname_zipfile = os.path.basename(zipfile_url)
+
+        fpath_save = os.path.join(DIRPATH_ZIPS, fname_zipfile)
+        if not os.path.exists(fpath_save):
+            request.urlretrieve(zipfile_url, fpath_save)
+        fpaths_zipfiles.append(fpath_save)
+
+    return fpaths_zipfiles
+
+
+def unzip_zipfiles(fpaths_zipfiles):
+    """Unzip the provided zipfiles to DIRPATH_IMAGES
+
+    :param fpaths_zipfiles: filepaths of the zipfiles to unzip
+    :type fpaths_zipfiles: list[str]
+    """
+
+    base_cmd = 'unzip -q -o {} -d {}'
+    for fpath_zipfile in tqdm(fpaths_zipfiles, total=len(fpaths_zipfiles)):
+        cmd = base_cmd.format(fpath_zipfile, DIRPATH_IMAGES)
+
+        process = subprocess.Popen(cmd.split())
+        process.communicate()
+
+
+def main():
+    """Main"""
+
+    if not os.path.exists(DIRPATH_ZIPS):
+        os.makedirs(DIRPATH_ZIPS, exist_ok=True)
+    if not os.path.exists(DIRPATH_IMAGES):
+        os.makedirs(DIRPATH_IMAGES, exist_ok=True)
+
+    fpaths_zipfiles = download_zips()
+    unzip_zipfiles(fpaths_zipfiles)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a script, largely based off of the `batch_download_zips.py` script in the [DeepLesion Box](https://nihcc.app.box.com/v/DeepLesion) that downloads all of the zipfiles for the `DeepLesion` dataset, and then unzips them into a specified location. Unfortunately, I wasn't able to find a publicly accessible link for the `DL_info.csv`, which contains associated metadata for all of the data. I think this will have to be downloaded manually from the Dropbox account. 