### PR TITLE
Add plotting script for images and bboxes of ImageNet

### DIFF
--- a/scripts/deep_lesion/create_training_dataframes.py
+++ b/scripts/deep_lesion/create_training_dataframes.py
@@ -24,13 +24,13 @@ FPATH_METADATA_CSV = os.path.join(
 )
 
 FPATH_TRAIN_SET = os.path.join(
-    DIRPATH_DATA, 'metadata_lists', 'df_train_set.csv'
+    DIRPATH_DATA, 'metadata_lists', 'df_train_set.pickle'
 )
 FPATH_VAL_SET = os.path.join(
-    DIRPATH_DATA, 'metadata_lists', 'df_val_set.csv'
+    DIRPATH_DATA, 'metadata_lists', 'df_val_set.pickle'
 )
 FPATH_TEST_SET = os.path.join(
-    DIRPATH_DATA, 'metadata_lists', 'df_test_set.csv'
+    DIRPATH_DATA, 'metadata_lists', 'df_test_set.pickle'
 )
 
 
@@ -159,11 +159,11 @@ def main():
     validate_splits(df_train, df_val, df_test)
 
     df_train.drop('dataset_split', axis=1, inplace=True)
-    df_train.to_csv(FPATH_TRAIN_SET, index=False)
+    df_train.to_pickle(FPATH_TRAIN_SET)
     df_val.drop('dataset_split', axis=1, inplace=True)
-    df_val.to_csv(FPATH_VAL_SET, index=False)
+    df_val.to_pickle(FPATH_VAL_SET)
     df_test.drop('dataset_split', axis=1, inplace=True)
-    df_test.to_csv(FPATH_TEST_SET, index=False)
+    df_test.to_pickle(FPATH_TEST_SET)
 
 
 if __name__ == '__main__':

--- a/scripts/imagenet/from_access_links/create_bbox_training_dataframes.py
+++ b/scripts/imagenet/from_access_links/create_bbox_training_dataframes.py
@@ -236,7 +236,7 @@ def main():
         )
 
         if set_name in {'train', 'val'}:
-            df_fpaths_inputs_targets = add_fpath_xml_column(
+            df_fpaths = add_fpath_xml_column(
                 df_fpaths_images, set_name, task_shortname
             )
 
@@ -244,7 +244,7 @@ def main():
             DIRPATH_METADATA_LISTS,
             'df_{}_{}_set.csv'.format(args.task, set_name)
         )
-        df_fpaths_inputs_targets.to_csv(fpath_set, index=False)
+        df_fpaths.to_csv(fpath_set, index=False)
 
 
 if __name__ == '__main__':

--- a/scripts/imagenet/plot_bboxes.py
+++ b/scripts/imagenet/plot_bboxes.py
@@ -1,0 +1,178 @@
+#! /usr/bin/env python
+"""Plot images and bbox annotations from the provided `df_fpaths`"""
+
+import argparse
+from collections import defaultdict
+from concurrent.futures import as_completed, ProcessPoolExecutor
+import multiprocessing
+import os
+import xml.etree.ElementTree as ET
+
+import imageio
+import matplotlib.patches as patches
+import matplotlib.pyplot as plt
+import pandas as pd
+from tqdm import tqdm
+
+
+N_PROCESSES = multiprocessing.cpu_count() // 2
+
+
+def parse_image_and_bboxes(fpath_image, fpath_xml):
+    """Return the image and bounding boxes from the provided filepaths
+
+    :param fpath_image: filepath to the image to parse
+    :type fpath_image: str
+    :param fpath_xml: filepath to the XML containing the bounding boxes for
+     the image at `fpath_image`
+    :type fpath_xml: str
+    :return: tuple of
+    - numpy.ndarray image: image data from `fpath_image`
+    - dict bboxes: dictionary where keys are strings representing the
+      synset ID and values are lists of bounding boxes, of shape
+      [xmin, ymin, xmax, ymax]
+    """
+
+    xml_tree = ET.parse(fpath_xml)
+    bboxes_xml = list(xml_tree.getroot().findall('./object/bndbox'))
+    bbox_synsets_xml = list(xml_tree.getroot().findall('.object/name'))
+
+    bboxes = defaultdict(list)
+    for bbox_xml, bbox_synset_xml in zip(bboxes_xml, bbox_synsets_xml):
+        bbox_as_dict = {}
+        for child in bbox_xml.getchildren():
+            bbox_as_dict[child.tag] = int(child.text)
+        bbox = [
+            bbox_as_dict['xmin'], bbox_as_dict['ymin'],
+            bbox_as_dict['xmax'], bbox_as_dict['ymax']
+        ]
+
+        synset = list(bbox_synset_xml.itertext())[0]
+        bboxes[synset].append(bbox)
+
+    image = imageio.imread(fpath_image)
+
+    return image, bboxes
+
+
+def plot_image_and_bboxes(fpath_image, fpath_xml, dirpath_output):
+    """Plot the image with the bounding boxes specified in `fpath_xml`
+
+    For each synset ID with bounding box labels in `fpath_imaage`, this will
+    save an image to the `dirpath_output/synset_id` with the same filename as
+    `os.path.basename(fpath_image)`.
+
+    :param fpath_image: filepath to the image to plot
+    :type fpath_image: str
+    :param fpath_xml: filepath to the XML containing the bounding boxes for
+     the image at `fpath_image`
+    :type fpath_xml: str
+    :param dirpath_output: directory path to save the plots in
+    :type dirpath_output: str
+    """
+
+    image, bboxes = parse_image_and_bboxes(fpath_image, fpath_xml)
+
+    for synset, bboxes_synset in bboxes.items():
+        _, ax = plt.subplots()
+        ax.imshow(image)
+        ax.axis('off')
+
+        for bbox_synset in bboxes_synset:
+            x_min, y_min, x_max, y_max = bbox_synset
+            rectangle = patches.Rectangle(
+                xy=(x_min, y_min),
+                width=(x_max - x_min),
+                height=(y_max - y_min),
+                linewidth=1.5,
+                fill=False,
+                color='r'
+            )
+
+            ax.add_patch(rectangle)
+
+        fname_image = os.path.basename(fpath_image)
+        fname_plot = '{}'.format(fname_image)
+
+        dirpath_plot = os.path.join(dirpath_output, synset)
+        if not os.path.exists(dirpath_plot):
+            os.makedirs(dirpath_plot)
+        fpath_plot = os.path.join(dirpath_plot, fname_plot)
+
+        plt.savefig(fpath_plot, bbox_inches='tight')
+
+
+def parse_args():
+    """Parse command line arguments
+
+    :return: name space holding the command line arguments
+    :rtype: argparse.Namespace
+    """
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--dirpath_output', type=str, required=True,
+        help=('Directory path to save plots in; if it doesn\'t exist, it will '
+              'be created.')
+    )
+    parser.add_argument(
+        '--fpath_df_fpaths', type=str, required=True,
+        help=(
+            'Filepath to a CSV full of image filepaths and bounding bbox '
+            'XMLs to plot. The CSV must contain a \'fpath_image\' and '
+            '\'fpath_xml\' column that point to the filepath of the image '
+            'and its corresponding XML file of bounding boxes.'
+        )
+    )
+
+    parser.add_argument(
+        '--n_images', type=int, default=100,
+        help='Number of images with bboxes to plot. Defaults to 100.'
+    )
+    parser.add_argument(
+        '--n_processes', type=int, default=N_PROCESSES,
+        help=(
+            'Number of processes to use to plot images, defaults to {}.'
+        ).format(N_PROCESSES)
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    """Main logic"""
+
+    args = parse_args()
+
+    if not os.path.exists(args.dirpath_output):
+        os.makedirs(args.dirpath_output)
+
+    df_fpaths = pd.read_csv(args.fpath_df_fpaths)
+    # ensure plotted images are always the same for a given set of command line
+    # arguments
+    df_fpaths.sort_values('fpath_image', inplace=True)
+    # randomly shuffle the data, but with a fixed seed so the plotted results
+    # are always the same
+    df_fpaths = df_fpaths.sample(frac=1, random_state=529)
+    df_fpaths = df_fpaths[:args.n_images]
+
+    it = df_fpaths[['fpath_image', 'fpath_xml']].values
+    with ProcessPoolExecutor(max_workers=args.n_processes) as process_pool:
+        futures = [
+            process_pool.submit(
+                plot_image_and_bboxes, fpath_image, fpath_xml,
+                args.dirpath_output
+            )
+            for fpath_image, fpath_xml in it
+        ]
+
+        it = tqdm(as_completed(futures), total=len(df_fpaths))
+        for _ in it:
+            pass
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/imagenet/plot_classifications.py
+++ b/scripts/imagenet/plot_classifications.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-"""Plot example images from the provided `df_fpaths_images`"""
+"""Plot images from the provided `df_fpaths_images`"""
 
 import argparse
 from concurrent.futures import as_completed, ProcessPoolExecutor
@@ -85,7 +85,11 @@ def plot_synset(df_fpaths_images, synset, n_images, dirpath_output):
 
 
 def parse_args():
-    """Parse command line arguments"""
+    """Parse command line arguments
+
+    :return: name space holding the command line arguments
+    :rtype: argparse.Namespace
+    """
 
     parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
This PR adds a script for plotting images and bounding boxes for the ImageNet data, e.g. 

![n07718747_23959](https://user-images.githubusercontent.com/12429170/47269496-51e72d80-d513-11e8-800e-a81c74f2c855.JPEG)

![image](https://user-images.githubusercontent.com/12429170/47269499-57dd0e80-d513-11e8-9a3a-fd5ab94f8a7e.png)

