### PR TITLE
Add unit tests for networks.Network

### DIFF
--- a/dl_playground/networks/network.py
+++ b/dl_playground/networks/network.py
@@ -15,10 +15,8 @@ class Network(object):
         :type network_config: dict
         """
 
-        msg = ('Class attribute `required_config_keys` must be specified, '
-               'but is None.')
-        assert self.required_config_keys, msg
-        validate_config(network_config, self.required_config_keys)
+        if self.required_config_keys:
+            validate_config(network_config, self.required_config_keys)
 
         self.network_config = network_config
 

--- a/tests/unit_tests/networks/test_network.py
+++ b/tests/unit_tests/networks/test_network.py
@@ -1,0 +1,35 @@
+"""Unit tests for networks.network"""
+
+from unittest.mock import MagicMock
+
+from networks.network import Network
+
+
+class TestNetwork(object):
+    """Tests for Network"""
+
+    def test_init(self, monkeypatch):
+        """Test __init__
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        monkeypatch.setattr(Network, 'required_config_keys', {'test1'})
+
+        mock_validate_config = MagicMock()
+        monkeypatch.setattr(
+            'networks.network.validate_config', mock_validate_config
+        )
+
+        network_configs = [
+            {'height': 227, 'width': 227,
+             'n_classes': 3, 'n_channels': 3},
+            {'test1': 'key1', 'test2': 'key2'}
+        ]
+
+        it = enumerate(network_configs, 1)
+        for expected_call_count, network_config in it:
+            network = Network(network_config)
+            assert network_config == network.network_config
+            assert mock_validate_config.call_count == expected_call_count


### PR DESCRIPTION
This PR adds a unit tests for the `networks.Network.__init__` method. 