### PR TITLE
Add `import_object` function

### DIFF
--- a/dl_playground/utils/generic_utils.py
+++ b/dl_playground/utils/generic_utils.py
@@ -1,5 +1,22 @@
 """Generic utilities used throughout dl-playground."""
 
+import importlib
+
+
+def import_object(object_importpath):
+    """Return the object specified by `object_importpath`
+
+    :param object_importpath: import path to the object to import
+    :type object_importpath: str
+    :return: object at `object_importpath`
+    :rtype: object
+    """
+
+    module_path, object_name = object_importpath.rsplit('.', 1)
+    module = importlib.import_module(module_path)
+
+    return getattr(module, object_name)
+
 
 def validate_config(config, required_keys):
     """Validate that the `config` has the `required_keys`

--- a/tests/unit_tests/utils/test_generic_utils.py
+++ b/tests/unit_tests/utils/test_generic_utils.py
@@ -2,9 +2,53 @@
 
 import random
 
+import numpy as np
+import pandas as pd
 import pytest
 
-from utils.generic_utils import validate_config
+from utils.generic_utils import import_object, validate_config
+
+
+class TestImportObject():
+    """Test `import_object` function"""
+
+    def test_import_object__dev_env(self, monkeypatch):
+        """Test `import_object` with utils.dev_env"""
+
+        def mock_dev_env_get(group, key):
+            """Mock `utils.dev_env.get` function"""
+            return '/data/imagenet'
+        monkeypatch.setattr('utils.dev_env.get', mock_dev_env_get)
+
+        get = import_object(object_importpath='utils.dev_env.get')
+        assert get('imagenet', 'dirpath_data') == '/data/imagenet'
+        assert get('mpii', 'dirpath_data') == '/data/imagenet'
+
+    def test_import_object__numpy(self):
+        """Test `import_object` with a numpy.array"""
+
+        NumpyArray = import_object(object_importpath='numpy.array')
+        array1 = NumpyArray([0, 1, 2, 3])
+        array2 = np.array([0, 1, 2, 3])
+
+        assert isinstance(array1, np.ndarray)
+        assert np.array_equal(array1, array2)
+
+    def test_import_object__pandas(self):
+        """Test `import_object` with a pandas.DataFrame"""
+
+        rows = [
+            {'a': 0, 'b': 1, 'c': 2},
+            {'a': 1, 'b': 2, 'c': 3},
+            {'a': 2, 'b': 3, 'c': 4}
+        ]
+
+        PandasDataFrame = import_object(object_importpath='pandas.DataFrame')
+        dataframe1 = PandasDataFrame(rows)
+        dataframe2 = pd.DataFrame(rows)
+
+        assert isinstance(dataframe1, pd.DataFrame)
+        assert dataframe1.equals(dataframe2)
 
 
 class TestValidateConfig():


### PR DESCRIPTION
This PR adds an `import_object` function, which will later allow for passing functions to apply within dataset classes as simple import paths via a config. 