### PR TITLE
Add PyTorchDataSetTransformer

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -38,6 +38,7 @@ class ImageNetDataSet(Dataset):
         - numpy.ndarray image: pixel data loaded from the `fpath_image` at
           index `idx` of `self.df_images`
         - int label: class label assigned to the returned image
+        :rtype: dict
         """
 
         fpath_image = self.df_images.loc[idx, 'fpath_image']

--- a/dl_playground/datasets/pytorch_dataset_transformer.py
+++ b/dl_playground/datasets/pytorch_dataset_transformer.py
@@ -1,0 +1,54 @@
+"""Transformer for transformations of a torch.utils.data.Dataset"""
+
+from torch.utils.data import Dataset
+
+from datasets.ops import apply_transformation
+
+
+class PyTorchDataSetTransformer(Dataset):
+    """Transformer to apply transformations to a torch.utils.data.Dataset"""
+
+    def __init__(self, numpy_dataset, transformations=None):
+        """Init
+
+        :param numpy_dataset: dataset that provies samples for training
+        :type numpy_dataset: torch.utils.data.Dataset object
+        :param transformations: holds 2 element tuples with the first element
+         being a function to apply to the dataset samples and the second
+         element being a dictionary of keyword arguments to pass to those
+         functions
+        :type transformations: list[tuple(function, dict)]
+        """
+
+        self.numpy_dataset = numpy_dataset
+        self.transformations = transformations or []
+
+    def __getitem__(self, idx):
+        """Return the transformed sample at index `idx` of `self.numpy_dataset`
+
+        :return: sample returned from `self.numpy_dataset.__getitem__`
+        :rtype: dict
+        """
+
+        sample = self.numpy_dataset[idx]
+
+        it = self.transformations
+        for transformation_fn, transformation_fn_kwargs in it:
+            transformation_fn_kwargs = transformation_fn_kwargs.copy()
+            sample_keys = transformation_fn_kwargs.pop('sample_keys')
+
+            sample = apply_transformation(
+                transformation_fn, sample, sample_keys,
+                transformation_fn_kwargs
+            )
+
+        return sample
+
+    def __len__(self):
+        """Return the size of the dataset
+
+        :return: size of the dataset
+        :rtype: int
+        """
+
+        return len(self.numpy_dataset)

--- a/dl_playground/datasets/tf_data_loader.py
+++ b/dl_playground/datasets/tf_data_loader.py
@@ -13,10 +13,10 @@ class TFDataLoader(object):
 
         :param numpy_dataset: dataset that provides samples for training
         :type numpy_dataset: torch.utils.data.Dataset object
-        :param transformations: holds 2 element tuples with the first
-         element being a function to apply to the dataset samples and the
-         second element being a dictionary of keyword arguments to pass to
-         those functions
+        :param transformations: holds 2 element tuples with the first element
+         being a function to apply to the dataset samples and the second
+         element being a dictionary of keyword arguments to pass to those
+         functions
         :type transformations: list[tuple(function, dict)]
         """
 

--- a/tests/unit_tests/datasets/test_imagenet_dataset.py
+++ b/tests/unit_tests/datasets/test_imagenet_dataset.py
@@ -54,7 +54,7 @@ class TestImageNetDataSet(object):
 
         assert len(imagenet_dataset) == 3
 
-    def test_get_item(self, df_images):
+    def test_getitem(self, df_images):
         """Test __getitem__ method
 
         :param df_images : df_images object fixture

--- a/tests/unit_tests/datasets/test_pytorch_dataset_transformer.py
+++ b/tests/unit_tests/datasets/test_pytorch_dataset_transformer.py
@@ -1,0 +1,65 @@
+"""Unit tests for datasets.pytorch_dataset_transformer"""
+
+from unittest.mock import MagicMock
+
+from datasets.pytorch_dataset_transformer import PyTorchDataSetTransformer
+
+
+class TestPyTorchDataSetTransformer(object):
+    """Tests for PyTorchDataSetTransformer"""
+
+    def test_init(self):
+        """Test __init__ method
+
+        This tests that all attributes are set correctly in the __init__.
+        """
+
+        numpy_dataset = MagicMock()
+        dataset_transformer = PyTorchDataSetTransformer(
+            numpy_dataset=numpy_dataset
+        )
+        assert id(dataset_transformer.numpy_dataset) == id(numpy_dataset)
+        assert not dataset_transformer.transformations
+
+        transformations = MagicMock()
+        dataset_transformer = PyTorchDataSetTransformer(
+            numpy_dataset=numpy_dataset, transformations=transformations
+        )
+        assert id(dataset_transformer.transformations) == id(transformations)
+
+    def test_getitem(self, monkeypatch):
+        """Test __getitem__ method"""
+
+        def mock_getitem(self, idx):
+            """Mock __getitem__ method for a numpy_datset"""
+            return {'element': idx, 'label': 1}
+
+        dataset_transformer = MagicMock()
+        dataset_transformer.numpy_dataset = MagicMock()
+        dataset_transformer.numpy_dataset.__getitem__ = mock_getitem
+        dataset_transformer.__getitem__ = PyTorchDataSetTransformer.__getitem__
+
+        mock_apply_transformation = MagicMock()
+        monkeypatch.setattr(
+            'datasets.pytorch_dataset_transformer.apply_transformation',
+            mock_apply_transformation
+        )
+
+        sample = dataset_transformer[10]
+        assert sample == {'element': 10, 'label': 1}
+        assert not mock_apply_transformation.call_count
+
+        mock_apply_transformation.return_value = 10
+        dataset_transformer.transformations = [
+            (0, {'sample_keys': ['element']}),
+            (1, {'sample_keys': ['label']}),
+            (2, {'sample_keys': ['element']})
+        ]
+        sample = dataset_transformer[10]
+        assert sample == 10
+        assert mock_apply_transformation.call_count == 3
+        mock_apply_transformation.assert_any_call(
+            0, {'element': 10, 'label': 1}, ['element'], {}
+        )
+        mock_apply_transformation.assert_any_call(1, 10, ['label'], {})
+        mock_apply_transformation.assert_called_with(2, 10, ['element'], {})


### PR DESCRIPTION
This PR adds a class for applying arbitrary transformations to a `torch.utils.data.Dataset`, in the same way that they were built for a `tensorflow.data.Dataset` in https://github.com/sallamander/dl-playground/pull/43. 