### PR TITLE
Add reshaping of images in numpy to `ImageNetDataSet`

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -1,23 +1,35 @@
 """Numpy backed dataset for training a model on ImageNet"""
 
 import imageio
+from skimage.transform import resize
 from torch.utils.data import Dataset
+
+from utils.generic_utils import validate_config
 
 
 class ImageNetDataSet(Dataset):
     """ImageNet dataset"""
 
     input_keys = ['image']
-    target_keys = ['label']
+    required_config_keys = {'height', 'width'}
     sample_types = {'image': 'float32', 'label': 'uint8'}
+    target_keys = ['label']
 
-    def __init__(self, df_images):
+    def __init__(self, df_images, dataset_config):
         """Init
 
+        `dataset_config` must contain the following keys:
+        - int height: height to reshape the images to
+        - int width: width to reshape the images to
+
+        :param dataset_config: specifies the configuration of the dataset
+        :type dataset_config: dict
         :param df_images: holds the filepath to the input image ('fpath_image')
          and the target label for the image ('label')
         :type df_images: pandas.DataFrame
         """
+
+        validate_config(dataset_config, self.required_config_keys)
 
         if set(df_images.columns) < {'fpath_image', 'label'}:
             msg = (
@@ -27,6 +39,7 @@ class ImageNetDataSet(Dataset):
             raise KeyError(msg)
 
         self.df_images = df_images
+        self.config = dataset_config
         self.df_images['label'] = (
             self.df_images['label'].astype(self.sample_types['label'])
         )
@@ -42,7 +55,15 @@ class ImageNetDataSet(Dataset):
         """
 
         fpath_image = self.df_images.loc[idx, 'fpath_image']
-        image = imageio.imread(fpath_image).astype(self.sample_types['image'])
+        image = imageio.imread(fpath_image)
+
+        n_channels = image.shape[-1]
+        target_shape = (
+            self.config['height'], self.config['width'], n_channels
+        )
+        image = resize(image, output_shape=target_shape)
+        image = image.astype(self.sample_types['image'])
+
         label = self.df_images.loc[idx, 'label']
         assert label.dtype == self.sample_types['label']
 

--- a/dl_playground/datasets/ops.py
+++ b/dl_playground/datasets/ops.py
@@ -1,7 +1,5 @@
 """Tensorflow operations for tf.Dataset objects"""
 
-import tensorflow as tf
-
 
 def apply_transformation(transformation_fn, sample, sample_keys,
                          transformation_fn_kwargs=None):
@@ -48,20 +46,3 @@ def format_batch(batch, input_keys, target_keys):
     inputs = {input_key: batch[input_key] for input_key in input_keys}
     targets = {target_key: batch[target_key] for target_key in target_keys}
     return (inputs, targets)
-
-
-def resize_images(images, size):
-    """Wrapper around tf.image.resize_images to resolve unknown shape errors
-
-    :param images: 4-D tensor of shape (batch, height, width, n_channels) or a
-     3-D tensor of shape (height, with, n_channels)
-    :type image: tensorflow.Tensor
-    :param size: the new (height, width) to resize `images` to
-    :type size: iterable of ints
-    :return: `images` resized
-    :rtype: tensorflow.Tensor
-    """
-
-    images.set_shape((None, None, None))
-    images = tf.image.resize_images(images, size=size)
-    return images

--- a/tests/integration_tests/datasets/test_tf_data_loader.py
+++ b/tests/integration_tests/datasets/test_tf_data_loader.py
@@ -4,7 +4,6 @@ import numpy as np
 import tensorflow as tf
 
 from datasets.imagenet_dataset import ImageNetDataSet
-from datasets.ops import resize_images
 from datasets.tf_data_loader import TFDataLoader
 from utils.test_utils import df_images
 
@@ -58,17 +57,15 @@ class TestTFDataLoader(object):
         :type df_images: pandas.DataFrame
         """
 
-        target_shape = (227, 227)
         transformations = [
-            (resize_images,
-             {'size': target_shape, 'sample_keys': ['image']}),
             (tf.one_hot,
              {'sample_keys': ['label'], 'depth': 1000}),
             (tf.image.per_image_standardization,
              {'sample_keys': ['image']}),
         ]
 
-        imagenet_dataset = ImageNetDataSet(df_images)
+        dataset_config = {'height': 227, 'width': 227}
+        imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
         tf_data_loader = TFDataLoader(imagenet_dataset, transformations)
 
         batches1 = self._get_batches(tf_data_loader)

--- a/tests/integration_tests/trainers/test_imagenet_trainer.py
+++ b/tests/integration_tests/trainers/test_imagenet_trainer.py
@@ -3,7 +3,6 @@
 import tensorflow as tf
 
 from datasets.imagenet_dataset import ImageNetDataSet
-from datasets.ops import resize_images
 from datasets.tf_data_loader import TFDataLoader
 from networks.alexnet_tf import AlexNet
 from trainers.imagenet_trainer import ImageNetTrainer
@@ -28,9 +27,8 @@ class TestImageNetTrainer(object):
             'optimizer': 'adam', 'loss': 'categorical_crossentropy',
             'batch_size': batch_size, 'num_epochs': 2
         }
+        dataset_config = {'height': height, 'width': width}
         transformations = [
-            (resize_images,
-             {'size': (height, width), 'sample_keys': ['image']}),
             (tf.one_hot,
              {'sample_keys': ['label'], 'depth': 1000}),
             (tf.image.per_image_standardization,
@@ -40,7 +38,7 @@ class TestImageNetTrainer(object):
         alexnet = AlexNet(network_config)
         imagenet_trainer = ImageNetTrainer(trainer_config)
 
-        imagenet_dataset = ImageNetDataSet(df_images)
+        imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
         tf_data_loader = TFDataLoader(imagenet_dataset)
         tf_data_loader = TFDataLoader(imagenet_dataset, transformations)
         dataset = tf_data_loader.get_infinite_iter(

--- a/tests/unit_tests/datasets/test_imagenet_dataset.py
+++ b/tests/unit_tests/datasets/test_imagenet_dataset.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import pytest
 
 import numpy as np
-import imageio
 
 from datasets.imagenet_dataset import ImageNetDataSet
 from utils.test_utils import df_images
@@ -13,10 +12,20 @@ from utils.test_utils import df_images
 class TestImageNetDataSet(object):
     """Tests for ImageNetDataSet"""
 
-    def test_init(self, df_images):
+    @pytest.fixture(scope='class')
+    def dataset_config(self):
+        """dataset_config object fixture
+
+        :return: dataset_config to be used for ImageNet training
+        :rtype: dict
+        """
+
+        return {'height': 227, 'width': 227}
+
+    def test_init(self, df_images, dataset_config, monkeypatch):
         """Test __init__ method
 
-        This tests two things:
+        This tests several things:
         - All attributes are set correctly in the __init__
         - A KeyError is raised if the fpath_image or label column is missing in
           the `df_images` passed to the __init__ of the ImageNetDataSet
@@ -24,18 +33,32 @@ class TestImageNetDataSet(object):
 
         :param df_images : df_images object fixture
         :type: pandas.DataFrame
+        :param dataset_config: dataset_config object fixture
+        :type: dict
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
         """
 
+        mock_validate_config = MagicMock()
+        monkeypatch.setattr(
+            'datasets.imagenet_dataset.validate_config', mock_validate_config
+        )
+
         # === test all attributes are set correctly === #
-        dataset = ImageNetDataSet(df_images)
+        dataset = ImageNetDataSet(df_images, dataset_config)
         assert dataset.df_images.equals(df_images)
+        assert dataset.config == dataset_config
+        assert dataset.required_config_keys == {'height', 'width'}
+        mock_validate_config.called_once_with(
+            dataset.config, dataset.required_config_keys
+        )
 
         # === test `df_images` === #
         for col in ['fpath_image', 'label']:
             df_images_underspecified = df_images.drop(col, axis=1)
 
             with pytest.raises(KeyError):
-                ImageNetDataSet(df_images_underspecified)
+                ImageNetDataSet(df_images_underspecified, dataset_config)
 
         # === test `sample_types` === #
         expected_sample_types = {'image': 'float32', 'label': 'uint8'}
@@ -54,11 +77,13 @@ class TestImageNetDataSet(object):
 
         assert len(imagenet_dataset) == 3
 
-    def test_getitem(self, df_images):
+    def test_getitem(self, df_images, dataset_config):
         """Test __getitem__ method
 
         :param df_images : df_images object fixture
         :type: pandas.DataFrame
+        :param dataset_config: dataset_config object fixture
+        :type: dict
         """
 
         sample_types = {'image': 'float16', 'label': 'int16'}
@@ -66,6 +91,7 @@ class TestImageNetDataSet(object):
 
         imagenet_dataset = MagicMock()
         imagenet_dataset.df_images = df_images
+        imagenet_dataset.config = dataset_config
         imagenet_dataset.sample_types = sample_types
         imagenet_dataset.__getitem__ = ImageNetDataSet.__getitem__
 
@@ -76,10 +102,7 @@ class TestImageNetDataSet(object):
             assert sample['label'].dtype == sample_types['label']
 
             assert sample['label'] == df_images.loc[idx, 'label']
-            assert np.array_equal(
-                sample['image'],
-                imageio.imread(df_images.loc[idx, 'fpath_image'])
-            )
+            assert sample['image'].shape == (227, 227, 3)
 
         with pytest.raises(KeyError):
             imagenet_dataset[4]

--- a/tests/unit_tests/datasets/test_ops.py
+++ b/tests/unit_tests/datasets/test_ops.py
@@ -77,25 +77,6 @@ def test_format_batch():
     assert np.array_equal(formatted_batch[1]['labels2'], labels2)
 
 
-def test_resize_images():
-    """Test resize_images"""
-
-    images = tf.placeholder(tf.float32, name='images')
-
-    target_shape = (227, 227)
-    resize_images_op = resize_images(images, target_shape)
-    with tf.Session() as sess:
-        resized_images = sess.run(
-            resize_images_op, feed_dict={images: np.ones((128, 64, 3))}
-        )
-    assert resized_images.shape == (227, 227, 3)
-
-    images = tf.placeholder(tf.float32, name='images')
-    images.set_shape = MagicMock()
-    with pytest.raises(ValueError):
-        resize_images_op = resize_images(images, target_shape)
-
-
 class TestApplyTransformation(object):
     """Tests for `apply_transformation` over different use cases"""
 


### PR DESCRIPTION
One of the goals of the `ImageNetDataSet` is to allow it to be used in both a `tensorflow.keras` pipeline as well as a `pytorch` pipeline. The functionality for reshaping in the way I wanted to didn't appear to be available in `pytorch`, but more importantly because of some of the discussions around the use of the `align_corners` arguments (see [this one](https://hackernoon.com/how-tensorflows-tf-image-resize-stole-60-days-of-my-life-aba5eb093f35) in particular), I think it's safest for the time being to resize with `skimage`.