### PR TITLE
Add integration tests for pytorch_dataset_transorfmer

### DIFF
--- a/tests/integration_tests/datasets/test_pytorch_dataset_transformer.py
+++ b/tests/integration_tests/datasets/test_pytorch_dataset_transformer.py
@@ -1,0 +1,34 @@
+"""Integration tests for datasets.pytorch_dataset_transformer"""
+
+from torch import Tensor
+from torchvision.transforms.functional import to_tensor
+
+from datasets.imagenet_dataset import ImageNetDataSet
+from datasets.pytorch_dataset_transformer import PyTorchDataSetTransformer
+from utils.test_utils import df_images
+
+
+class TestPyTorchDataSetTransformer(object):
+    """Tests for PyTorchDataSetTransformer"""
+
+    def test_getitem(self, df_images):
+        """Test __getitem__ method
+
+        :param df_images: df_images object fixture
+        :type df_images: pandas.DataFrame
+        """
+
+        dataset_config = {'height': 227, 'width': 227}
+        imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
+
+        transformations = [(to_tensor, {'sample_keys': ['image']})]
+        imagenet_datsaet_transformed = PyTorchDataSetTransformer(
+            numpy_dataset=imagenet_dataset, transformations=transformations
+        )
+
+        for idx in range(2):
+            sample = imagenet_datsaet_transformed[idx]
+            assert set(sample) == {'image', 'label'}
+            assert sample['image'].shape == (3, 227, 227)
+            assert isinstance(sample['image'], Tensor)
+            assert sample['label'] == idx

--- a/tests/unit_tests/datasets/test_ops.py
+++ b/tests/unit_tests/datasets/test_ops.py
@@ -1,12 +1,10 @@
 """Unit tests for datasets.ops"""
 
-from unittest.mock import MagicMock
-
 import numpy as np
 import pytest
 import tensorflow as tf
 
-from datasets.ops import apply_transformation, format_batch, resize_images
+from datasets.ops import apply_transformation, format_batch
 
 
 @pytest.fixture(scope='module')
@@ -141,40 +139,3 @@ class TestApplyTransformation(object):
         assert sample_one_hotted['image'].shape == sample['image'].shape
         assert sample_one_hotted['label'].shape == (num_classes, )
         assert sample_one_hotted['label'].argmax() == 1
-
-    @pytest.mark.parametrize('target_image_shape', [
-        (227, 227), (64, 64), (128, 196), (64, 32)
-    ])
-    def test_apply_transformation__resize_images(self, image, label,
-                                                 target_image_shape):
-        """Test `apply_transformation` with `tf.image_resize_images`
-
-        `label` is not directly used in the testing, but is still included to
-        simulate a more realistic scenario where the `sample` has a 'label'
-        key.
-
-        :param image: module wide image object fixture
-        :type image: tensorflow.Tensor
-        :param label: module wide label object fixture
-        :type label: tensorflow.Tensor
-        :param target_image_shape: (height, width) to reshape `image` to
-        :type target_image_shape: tuple(int)
-        """
-
-        sample = {'image1': image, 'image2': image, 'label': label}
-        sample_keys = {'image1', 'image2'}
-        transformation_fn = tf.image.resize_images
-        transformation_fn_kwargs = {'size': target_image_shape}
-
-        sample_resized_op = apply_transformation(
-            transformation_fn, sample, sample_keys, transformation_fn_kwargs
-        )
-
-        with tf.Session() as sess:
-            sample_resized = sess.run(sample_resized_op)
-
-        num_channels = (3, )
-        expected_target_shape = target_image_shape + num_channels
-        assert sample_resized['image1'].shape == expected_target_shape
-        assert sample_resized['image2'].shape == expected_target_shape
-        assert sample_resized['label'] == 1

--- a/tests/unit_tests/datasets/test_pytorch_dataset_transformer.py
+++ b/tests/unit_tests/datasets/test_pytorch_dataset_transformer.py
@@ -63,3 +63,17 @@ class TestPyTorchDataSetTransformer(object):
         )
         mock_apply_transformation.assert_any_call(1, 10, ['label'], {})
         mock_apply_transformation.assert_called_with(2, 10, ['element'], {})
+
+    def test_len(self):
+        """Test __len__ method"""
+
+        dataset_transformer = MagicMock()
+        dataset_transformer.__len__ = PyTorchDataSetTransformer.__len__
+        dataset_transformer.numpy_dataset = MagicMock()
+
+        mock_len = MagicMock()
+        dataset_transformer.numpy_dataset.__len__ = mock_len
+
+        for len_value in [1, 3, 5]:
+            mock_len.return_value = len_value
+            assert len(dataset_transformer) == len_value


### PR DESCRIPTION
This PR primarily adds integration tests for some of the functionality of the `PyTorchDataSetTransformer` class, but it also adds a test fo the `__len__` method of that class, and deletes a test that should have been deleted in https://github.com/sallamander/dl-playground/pull/49. 