### PR TITLE
Add per_image_standardization for numpy arrays

### DIFF
--- a/dl_playground/datasets/ops.py
+++ b/dl_playground/datasets/ops.py
@@ -1,5 +1,7 @@
 """Tensorflow operations for tf.Dataset objects"""
 
+import numpy as np
+
 
 def apply_transformation(transformation_fn, sample, sample_keys,
                          transformation_fn_kwargs=None):
@@ -29,6 +31,11 @@ def apply_transformation(transformation_fn, sample, sample_keys,
     return sample
 
 
+##############
+# tensorflow #
+##############
+
+
 def format_batch(batch, input_keys, target_keys):
     """Format the batch from a single dictionary into a tuple of dictionaries
 
@@ -46,3 +53,34 @@ def format_batch(batch, input_keys, target_keys):
     inputs = {input_key: batch[input_key] for input_key in input_keys}
     targets = {target_key: batch[target_key] for target_key in target_keys}
     return (inputs, targets)
+
+
+###########
+# pytorch #
+###########
+
+
+def per_image_standardization(image):
+    """Return the provided `image` with zero mean and unit variance
+
+    This mimics the `tensorflow.image.per_image_standardization`
+    implementation, located at
+    https://www.tensorflow.org/api_docs/python/tf/image/per_image_standardization.
+
+    :param image: image data to standardize, of shape (height, width,
+     n_channels)
+    :type image: numpy.ndarray
+    :return: `image` standardized to have zero mean and unit variance
+    :rtype: numpy.ndarray
+    """
+
+    if image.ndim != 3:
+        msg = '`image` must have 3 dimensions, but has shape {}'
+        raise ValueError(msg.format(image.shape))
+
+    image_mean = image.mean()
+    min_std = 1 / np.sqrt(image.size)
+    image_std = max(image.std(), min_std)
+
+    image = (image - image_mean) / image_std
+    return image


### PR DESCRIPTION
This PR adds a `per_image_standardization` for numpy arrays, with the intent of using it in pytorch training pipelines. It mirrors the [tf.image.per_image_standardization](https://www.tensorflow.org/api_docs/python/tf/image/per_image_standardization) function.