### PR TITLE
Add `Model` wrapper for pytorch networks

### DIFF
--- a/dl_playground/trainers/pytorch_model.py
+++ b/dl_playground/trainers/pytorch_model.py
@@ -1,0 +1,103 @@
+"""Class for training / evaluating pytorch networks
+
+Reference Implementations:
+- https://github.com/keras-team/keras/blob/master/keras/engine/training.py
+"""
+
+import torch
+
+
+class Model(object):
+    """Model for training / evaluating pytorch networks
+
+    Reference Implementation:
+    - https://github.com/keras-team/keras/blob/master/keras/engine/training.py
+    """
+
+    def __init__(self, network, device=None):
+        """Init
+
+        :param network: pytorch network to train or evaluate
+        :type network: torch.nn.Module
+        :param device: device to train the network on, e.g. 'cuda:0'
+        :type device: str
+        """
+
+        self.network = network
+        self.device = device
+
+        self._compiled = False
+        # these are set in the `compile` method
+        self.optimizer = None
+        self.loss = None
+
+    def compile(self, optimizer, loss):
+        """Setup the model for training
+
+        This sets `self.optimizer` and `self.loss` in place.
+
+        :param optimizer: class name of the optimizer to use when training, one
+         of those from `torch.optim` (e.g. `Adam`)
+        :type optimizer: str
+        :param loss: class name of the loss to use when training, one of those
+         from `torch.nn` (e.g. `CrossEntropyLoss`)
+        :type loss: str
+        :raises AttributeError: if an invalid optimizer or loss function is
+         specified
+        """
+
+        try:
+            Optimizer = getattr(torch.optim, optimizer)
+        except AttributeError:
+            msg = (
+                '`optimizer` must be a `str` representing an optimizer from '
+                'the `torch.optim` package, and {} is not a valid one.'
+            )
+            raise AttributeError(msg.format(optimizer))
+        self.optimizer = Optimizer(self.network.parameters())
+
+        try:
+            Loss = getattr(torch.nn, loss)
+        except AttributeError:
+            msg = (
+                '`loss` must be a `str` representing a loss from '
+                'the `torch.nn` package, and {} is not a valid one.'
+            )
+            raise AttributeError(msg.format(loss))
+        self.loss = Loss()
+
+        self._compiled = True
+
+    def fit_generator(self, generator, n_steps_per_epoch, n_epochs=1):
+        """Train the network on data generated batch-by-batch from `generator`
+
+        :param generator: a generator yielding batches indefinitely, where each
+         batch is a tuple of (inputs, targets)
+        :type generator: generator
+        :param n_steps_per_epoch: number of batches to train on in one epoch
+        :type n_steps_per_epoch: int
+        :param n_epochs: number of epochs to train the model
+        :type n_epochs: int
+        """
+
+        if not self._compiled:
+            msg = ('Model must be compiled before training; please call '
+                   'the `compile` method before training.')
+            raise RuntimeError(msg)
+
+        if self.device:
+            self.network.to(self.device)
+
+        for _ in range(n_epochs):
+            for _ in range(n_steps_per_epoch):
+                inputs, targets = next(generator)
+                if self.device:
+                    inputs = inputs.to(self.device)
+                    targets = targets.to(self.device)
+
+                outputs = self.network(inputs)
+                loss = self.loss(outputs, targets)
+
+                self.optimizer.zero_grad()
+                loss.backward()
+                self.optimizer.step()

--- a/tests/unit_tests/trainers/test_pytorch_model.py
+++ b/tests/unit_tests/trainers/test_pytorch_model.py
@@ -1,0 +1,145 @@
+"""Unit tests for trainers.pytorch_model"""
+
+from itertools import product
+from unittest.mock import MagicMock
+import pytest
+
+import torch
+
+from trainers.pytorch_model import Model
+
+
+class TestModel(object):
+    """Tests for Model"""
+
+    def test_init(self):
+        """Test __init__ method
+
+        This tests that all attributes are set correctly in the __init__.
+        """
+
+        network = MagicMock()
+        device = MagicMock()
+
+        model = Model(network, device)
+        assert id(network) == id(model.network)
+        assert id(device) == id(model.device)
+        assert not model._compiled
+        assert not model.optimizer
+        assert not model.loss
+
+        model = Model(network)
+        assert not model.device
+
+    def test_compile(self):
+        """Test compile method
+
+        This tests several things:
+        - An `AttributeError` is raised if an invalid optimizer or loss
+          function is passed in
+        - `Model.loss` and `Model.optimizer` are set correctly when a valid
+          optimizer and loss are passed in
+        - `Model._compiled` is True after `compile` is called
+        """
+
+        model = MagicMock()
+        model.optimizer = None
+        model.loss = None
+        model._compiled = False
+        model.compile = Model.compile
+
+        network = MagicMock()
+        parameters_fn = MagicMock()
+        parameters_fn.return_value = [
+            torch.nn.Parameter(torch.randn((64, 64)))
+        ]
+        network.parameters = parameters_fn
+        model.network = network
+
+        valid_optimizers = ['Adam', 'RMSprop']
+        valid_losses = ['BCELoss', 'CrossEntropyLoss', 'L1Loss']
+
+        for optimizer, loss in product(valid_optimizers, valid_losses):
+            assert not model.optimizer
+            assert not model.loss
+            assert not model._compiled
+
+            model.compile(self=model, optimizer=optimizer, loss=loss)
+
+            assert model.optimizer
+            assert model.loss
+            assert model._compiled
+
+            # reset for next iteration
+            model.optimizer = None
+            model.loss = None
+            model._compiled = False
+
+        with pytest.raises(AttributeError):
+            model.compile(self=model, optimizer='BadOptimizer', loss='BCELoss')
+
+        with pytest.raises(AttributeError):
+            model.compile(self=model, optimizer='Adam', loss='BadLoss')
+
+    def test_fit_generator__compiled(self):
+        """Test fit_generator method when the network is compiled first
+
+        This tests that the correct total number of steps are taken for a given
+        `fit_generator` call with a specified `n_steps_per_epoch` and
+        `n_epochs`.
+        """
+
+        def mock_generator_fn():
+            """Mock generator yielding (inputs, targets) indefinitely"""
+
+            inputs = torch.randn((2, 64, 64, 3))
+            targets = torch.randn((2, 1))
+
+            while True:
+                yield (inputs, targets)
+
+        model = MagicMock()
+        model.fit_generator = Model.fit_generator
+        model._compiled = True
+        model.network = MagicMock()
+        model.loss = MagicMock()
+
+        test_cases = [
+            {'n_steps_per_epoch': 1, 'n_epochs': 1, 'device': 'cpu'},
+            {'n_steps_per_epoch': 2, 'n_epochs': 2},
+            {'n_steps_per_epoch': 223, 'n_epochs': 50, 'device': 'cpu'}
+        ]
+
+        for test_case in test_cases:
+            n_steps_per_epoch = test_case['n_steps_per_epoch']
+            n_epochs = test_case['n_epochs']
+            device = test_case.get('device')
+
+            model.device = device
+            model.fit_generator(
+                self=model, generator=mock_generator_fn(),
+                n_steps_per_epoch=n_steps_per_epoch, n_epochs=n_epochs
+            )
+
+            assert model.loss.call_count == n_steps_per_epoch * n_epochs
+            assert model.network.call_count == n_steps_per_epoch * n_epochs
+
+            model.loss.call_count = 0
+            model.network.call_count = 0
+
+    def test_fit_generator__not_compiled(self):
+        """Test fit_generator method when the network is not compiled first
+
+        This simply tests that a RuntimeError is raised if the network is not
+        compiled before `fit_generator` is called.
+        """
+
+        model = MagicMock()
+        model.fit_generator = Model.fit_generator
+
+        model._compiled = False
+        with pytest.raises(RuntimeError):
+            model.fit_generator(
+                self=model, generator=MagicMock(), n_steps_per_epoch=1,
+                n_epochs=1
+            )


### PR DESCRIPTION
This creates a very minimalistic version of a `Model` class that can be used with `pytorch` networks. It is akin to the `keras.training.Model` class, albeit much more simplistic and with slightly different APIs. Additional functionality will be added over time, and the APIs will be updated to match as closely as possible to the `keras.training.Model` class. 