### PR TITLE
Add integration tests for pytorch `Model` class

### DIFF
--- a/dl_playground/datasets/pytorch_dataset_transformer.py
+++ b/dl_playground/datasets/pytorch_dataset_transformer.py
@@ -42,7 +42,19 @@ class PyTorchDataSetTransformer(Dataset):
                 transformation_fn_kwargs
             )
 
-        return sample
+        inputs = [
+            sample[input_key] for input_key in self.numpy_dataset.input_keys
+        ]
+        targets = [
+            sample[target_key] for target_key in self.numpy_dataset.target_keys
+        ]
+
+        if len(inputs) == 1:
+            inputs = inputs[0]
+        if len(targets) == 1:
+            targets = targets[0]
+
+        return inputs, targets
 
     def __len__(self):
         """Return the size of the dataset

--- a/dl_playground/trainers/pytorch_model.py
+++ b/dl_playground/trainers/pytorch_model.py
@@ -96,7 +96,7 @@ class Model(object):
                     targets = targets.to(self.device)
 
                 outputs = self.network(inputs)
-                loss = self.loss(outputs, targets)
+                loss = self.loss(outputs, targets.long())
 
                 self.optimizer.zero_grad()
                 loss.backward()

--- a/tests/integration_tests/datasets/test_pytorch_dataset_transformer.py
+++ b/tests/integration_tests/datasets/test_pytorch_dataset_transformer.py
@@ -32,12 +32,11 @@ class TestPyTorchDataSetTransformer(object):
         )
 
         for idx in range(2):
-            sample = imagenet_datsaet_transformed[idx]
-            assert set(sample) == {'image', 'label'}
+            image, label = imagenet_datsaet_transformed[idx]
 
-            assert sample['image'].shape == (3, 227, 227)
-            assert np.allclose(sample['image'].mean(), 0, atol=1e-6)
-            assert np.allclose(sample['image'].std(), 1, atol=1e-6)
-            assert isinstance(sample['image'], Tensor)
+            assert image.shape == (3, 227, 227)
+            assert np.allclose(image.mean(), 0, atol=1e-6)
+            assert np.allclose(image.std(), 1, atol=1e-6)
+            assert isinstance(image, Tensor)
 
-            assert sample['label'] == idx
+            assert label == idx

--- a/tests/integration_tests/trainers/test_pytorch_model.py
+++ b/tests/integration_tests/trainers/test_pytorch_model.py
@@ -1,0 +1,55 @@
+"""Integration tests for trainers.pytorch_model"""
+
+from itertools import cycle
+from unittest.mock import patch
+
+from torch.utils.data import DataLoader
+from torchvision.transforms.functional import to_tensor
+
+from datasets.imagenet_dataset import ImageNetDataSet
+from datasets.ops import per_image_standardization
+from datasets.pytorch_dataset_transformer import PyTorchDataSetTransformer
+from networks.alexnet_pytorch import AlexNet
+from trainers.pytorch_model import Model
+from utils.test_utils import df_images
+
+
+class TestModel(object):
+    """Tests for Model"""
+
+    def test_fit_generator(self, df_images):
+        """Test fit_generator_method"""
+
+        dataset_config = {'height': 227, 'width': 227}
+        train_dataset = ImageNetDataSet(df_images, dataset_config)
+        transformations = [
+            (per_image_standardization, {'sample_keys': ['image']}),
+            (to_tensor, {'sample_keys': ['image']}),
+        ]
+        train_dataset = PyTorchDataSetTransformer(
+            numpy_dataset=train_dataset, transformations=transformations
+        )
+        train_loader = DataLoader(
+            dataset=train_dataset, batch_size=2,
+            shuffle=True, num_workers=0
+        )
+
+        alexnet = AlexNet(network_config={'n_channels': 3, 'n_classes': 1000})
+
+        model = Model(network=alexnet)
+
+        assert not model._compiled
+        assert not model.optimizer
+        assert not model.loss
+        model.compile(optimizer='Adam', loss='CrossEntropyLoss')
+        assert model._compiled
+        assert model.optimizer
+        assert model.loss
+
+        with patch.object(model, 'loss', wraps=model.loss) as patched_loss:
+            model.fit_generator(
+                generator=cycle(train_loader),
+                n_steps_per_epoch=2, n_epochs=2
+            )
+
+            assert patched_loss.call_count == 4


### PR DESCRIPTION
This PR adds an integration test for the pytorch `Model` class added in #54, and makes some updates to other functionality to allow for end-to-end training.