### PR TITLE
Add `cycle` function that doesn't cache elements

### DIFF
--- a/dl_playground/utils/generic_utils.py
+++ b/dl_playground/utils/generic_utils.py
@@ -3,6 +3,31 @@
 import importlib
 
 
+def cycle(iterable):
+    """Cycle over `iterable` without caching individual iterable elements
+
+    The `itertools.cycle` function caches the results of iterable elements
+    during the first pass, and in subsequent passes uses the cached results.
+    For iterables to return non-deterministic output, the caching must not be
+    used.
+
+    Reference implementation: https://stackoverflow.com/a/49987606
+
+    :param iterable: iterable object to cycle over; must implement the
+     `__iter__` magic method
+    :type iterable: Iterable
+    """
+
+    if not hasattr(iterable, '__iter__'):
+        msg = ('`iterable` must implement the `__iter__` magic method, but '
+               'doesn\'t.')
+        raise AttributeError(msg)
+
+    while True:
+        for element in iterable:
+            yield element
+
+
 def import_object(object_importpath):
     """Return the object specified by `object_importpath`
 

--- a/tests/integration_tests/trainers/test_pytorch_model.py
+++ b/tests/integration_tests/trainers/test_pytorch_model.py
@@ -1,6 +1,5 @@
 """Integration tests for trainers.pytorch_model"""
 
-from itertools import cycle
 from unittest.mock import patch
 
 from torch.utils.data import DataLoader
@@ -11,6 +10,7 @@ from datasets.ops import per_image_standardization
 from datasets.pytorch_dataset_transformer import PyTorchDataSetTransformer
 from networks.alexnet_pytorch import AlexNet
 from trainers.pytorch_model import Model
+from utils.generic_utils import cycle
 from utils.test_utils import df_images
 
 

--- a/tests/unit_tests/utils/test_generic_utils.py
+++ b/tests/unit_tests/utils/test_generic_utils.py
@@ -1,12 +1,88 @@
 """Unit tests for utils.generic_utils"""
 
+from itertools import cycle as itertools_cycle
 import random
 
 import numpy as np
 import pandas as pd
 import pytest
 
-from utils.generic_utils import import_object, validate_config
+from utils.generic_utils import cycle, import_object, validate_config
+
+
+class TestCycle(object):
+    """Test `cycle` function"""
+
+    def test_cycle__bad_iterable(self):
+        """Test `cycle` when the iterable doesn't implement `__iter__`"""
+
+        def iterable():
+            for element in range(5):
+                yield element
+
+        with pytest.raises(AttributeError):
+            cycle_iter = cycle(iterable)
+            for _ in range(5):
+                next(cycle_iter)
+
+    def test_cycle__deterministic(self):
+        """Test `cycle` when the iterable yields elements deterministically"""
+
+        class DeterministicIter(object):
+
+            def __iter__(self):
+                for element in range(5):
+                    yield element
+
+        cycle_iter = cycle(DeterministicIter())
+        for idx_element in range(10):
+            expected_element = idx_element % 5
+            element = next(cycle_iter)
+            assert element == expected_element
+
+    def test_cycle__nondeterministic(self):
+        """Test `cycle` when the iterable yields elements non-deterministically
+
+        This compares the output of the `cycle` function with that of the
+        `itertools.cycle` function. The former should return different sets of
+        elements when cycling over the iterable twice, whereas the latter
+        should return the same sets of elements, since it caches the results of
+        the returned elements during the first pass.
+        """
+
+        class NonDeterministicIter(object):
+
+            def __init__(self, seeds):
+                self.cycle = 0
+                self.seeds = seeds
+
+            def __iter__(self):
+
+                np.random.seed(self.seeds[self.cycle])
+                for element in np.random.randint(0, 1000, size=5):
+                    yield element
+                self.cycle += 1
+
+        itertools_cycle_iter = itertools_cycle(
+            NonDeterministicIter(seeds=[1226, 42])
+        )
+        non_itertools_cycle_iter = cycle(
+            NonDeterministicIter(seeds=[1226, 42])
+        )
+
+        itertools_batch1 = [next(itertools_cycle_iter) for _ in range(5)]
+        itertools_batch2 = [next(itertools_cycle_iter) for _ in range(5)]
+
+        non_itertools_batch1 = [
+            next(non_itertools_cycle_iter) for _ in range(5)
+        ]
+        non_itertools_batch2 = [
+            next(non_itertools_cycle_iter) for _ in range(5)
+        ]
+
+        assert np.array_equal(itertools_batch1, itertools_batch2)
+        assert np.array_equal(itertools_batch1, non_itertools_batch1)
+        assert not np.array_equal(non_itertools_batch1, non_itertools_batch2)
 
 
 class TestImportObject(object):


### PR DESCRIPTION
This PR adds a variation of the `itertools.cycle` function that doesn't cache results during the first pass of the iterable.  This allows for iterating over a `torch.utils.data.DataLoader` indefinitely while at the same time respecting a `shuffle=True` argument, per [this SO post](https://stackoverflow.com/a/49987606). 