### PR TITLE
Cleanup manual cast to long in `Model` class

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -1,6 +1,7 @@
 """Numpy backed dataset for training a model on ImageNet"""
 
 import imageio
+import numpy as np
 from skimage.transform import resize
 from torch.utils.data import Dataset
 
@@ -64,7 +65,7 @@ class ImageNetDataSet(Dataset):
         image = resize(image, output_shape=target_shape)
         image = image.astype(self.sample_types['image'])
 
-        label = self.df_images.loc[idx, 'label']
+        label = np.array(self.df_images.loc[idx, 'label'])
         assert label.dtype == self.sample_types['label']
 
         sample = {'image': image, 'label': label}

--- a/dl_playground/trainers/pytorch_model.py
+++ b/dl_playground/trainers/pytorch_model.py
@@ -96,7 +96,7 @@ class Model(object):
                     targets = targets.to(self.device)
 
                 outputs = self.network(inputs)
-                loss = self.loss(outputs, targets.long())
+                loss = self.loss(outputs, targets)
 
                 self.optimizer.zero_grad()
                 loss.backward()

--- a/tests/integration_tests/trainers/test_pytorch_model.py
+++ b/tests/integration_tests/trainers/test_pytorch_model.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import torch
 from torch.utils.data import DataLoader
 from torchvision.transforms.functional import to_tensor
 
@@ -25,6 +26,7 @@ class TestModel(object):
         transformations = [
             (per_image_standardization, {'sample_keys': ['image']}),
             (to_tensor, {'sample_keys': ['image']}),
+            (torch.tensor, {'sample_keys': ['label'], 'dtype': torch.long})
         ]
         train_dataset = PyTorchDataSetTransformer(
             numpy_dataset=train_dataset, transformations=transformations


### PR DESCRIPTION
This PR cleans up a manual cast of the `targets` to `long` type in the `Model.fit_generator` method; at the time of writing, it was implemented to get tests passing with the intent of coming back to fix it. This fixes it, and instead moves that cast to the `transformations` section of the training pipeline. 