### PR TITLE
Fix multiple worker support during training

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -5,7 +5,7 @@ import numpy as np
 from skimage.transform import resize
 from torch.utils.data import Dataset, DataLoader
 
-from utils.generic_utils import validate_config
+from utils.generic_utils import cycle, validate_config
 
 
 class ImageNetDataSet(Dataset):
@@ -84,7 +84,7 @@ class ImageNetDataSet(Dataset):
 
         return len(self.df_images)
 
-    def as_generator(self, shuffle=False):
+    def as_generator(self, shuffle=False, n_workers=0):
         """Return a generator that yields the entire dataset once
 
         This is intended to act as a lightweight wrapper around the
@@ -96,11 +96,16 @@ class ImageNetDataSet(Dataset):
 
         :param shuffle: if True, shuffle the data before returning it
         :type shuffle: bool
+        :param n_workers: number of subprocesses to use for data loading
+        :type n_workers: int
         :return: generator that yields the entire dataset once
         :rtype: generator
         """
 
-        for sample in DataLoader(dataset=self, shuffle=shuffle):
+        data_loader = DataLoader(
+            dataset=self, shuffle=shuffle, num_workers=n_workers
+        )
+        for sample in cycle(data_loader):
             sample_batch_dim_removed = {}
             for key, val in sample.items():
                 sample_batch_dim_removed[key] = val[0]

--- a/scripts/imagenet/train_alexnet_pytorch.py
+++ b/scripts/imagenet/train_alexnet_pytorch.py
@@ -60,11 +60,11 @@ def get_data_loaders():
 
     train_loader = DataLoader(
         dataset=train_dataset, batch_size=BATCH_SIZE,
-        shuffle=True, num_workers=0
+        shuffle=True, num_workers=4
     )
     val_loader = DataLoader(
         dataset=val_dataset, batch_size=BATCH_SIZE,
-        shuffle=True, num_workers=0
+        shuffle=False, num_workers=2
     )
 
     return train_loader, val_loader
@@ -88,6 +88,7 @@ def get_trainer():
     :rtype: trainers.imagenet_trainer_pytorch.ImageNetTrainer
     """
 
+    os.environ['CUDA_VISIBLE_DEVICES'] = '0'
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     trainer_config = {
         'optimizer': 'Adam', 'loss': 'CrossEntropyLoss',
@@ -105,9 +106,9 @@ def main():
 
     trainer.train(
         network=alexnet, train_dataset=train_loader,
-        n_steps_per_epoch=len(train_loader.dataset),
+        n_steps_per_epoch=len(train_loader),
         validation_dataset=val_loader,
-        n_validation_steps=len(val_loader.dataset)
+        n_validation_steps=len(val_loader)
     )
 
 

--- a/scripts/imagenet/train_alexnet_tf.py
+++ b/scripts/imagenet/train_alexnet_tf.py
@@ -91,8 +91,12 @@ def main():
     alexnet = get_network()
     trainer = get_trainer()
 
-    train_dataset = train_loader.get_infinite_iter(BATCH_SIZE, shuffle=True)
-    validation_dataset = validation_loader.get_infinite_iter(BATCH_SIZE)
+    train_dataset = train_loader.get_infinite_iter(
+        BATCH_SIZE, shuffle=True, n_workers=4
+    )
+    validation_dataset = validation_loader.get_infinite_iter(
+        BATCH_SIZE, shuffle=False, n_workers=2
+    )
 
     os.environ['CUDA_VISIBLE_DEVICES'] = '0'
     trainer.train(

--- a/tests/integration_tests/training/pytorch/test_model.py
+++ b/tests/integration_tests/training/pytorch/test_model.py
@@ -33,7 +33,7 @@ class TestModel(object):
         )
         data_loader = DataLoader(
             dataset=dataset, batch_size=2,
-            shuffle=True, num_workers=0
+            shuffle=True, num_workers=4
         )
 
         alexnet = AlexNet(network_config={'n_channels': 3, 'n_classes': 1000})

--- a/tests/integration_tests/training/tf/test_imagenet_trainer.py
+++ b/tests/integration_tests/training/tf/test_imagenet_trainer.py
@@ -42,7 +42,7 @@ class TestImageNetTrainer(object):
         tf_data_loader = TFDataLoader(imagenet_dataset)
         tf_data_loader = TFDataLoader(imagenet_dataset, transformations)
         dataset = tf_data_loader.get_infinite_iter(
-            batch_size=batch_size
+            batch_size=batch_size, shuffle=True, n_workers=4
         )
 
         imagenet_trainer.train(

--- a/tests/unit_tests/training/tf/test_data_loader.py
+++ b/tests/unit_tests/training/tf/test_data_loader.py
@@ -6,6 +6,7 @@ import numpy as np
 import tensorflow as tf
 
 from training.tf.data_loader import TFDataLoader
+from utils.generic_utils import cycle
 from utils.test_utils import df_images
 
 
@@ -25,7 +26,7 @@ class TestTFDataLoader(object):
 
         with tf.device('/cpu:0'):
             dataset = tf_data_loader.get_infinite_iter(
-                self=tf_data_loader, batch_size=self.BATCH_SIZE,
+                self=tf_data_loader, batch_size=self.BATCH_SIZE, n_workers=0
             )
             iterator = dataset.make_initializable_iterator()
             next_element_op = iterator.get_next()
@@ -60,10 +61,10 @@ class TestTFDataLoader(object):
     def test_get_infinite_iter(self):
         """Test get_infinite_iter method"""
 
-        def mock_call(shuffle=False):
+        def mock_call(shuffle=False, n_workers=1):
             """Mock __call__ magic method"""
 
-            for element in np.arange(4, dtype='float32'):
+            for element in cycle(np.arange(4, dtype='float32')):
                 yield {'element': element, 'label': 1}
 
         def return_max_val(element, ceiling):


### PR DESCRIPTION
Multiple worker support of loading batches wasn't properly enabled during training, and this PR (in conjunction with #65) fixes that. There is still an issue in testing in which some of the integration tests hang when trying to use multiple workers, but I think this is more an issue with using the same exact image filepaths in multiple `DataLoader` objects. The training scripts present in `scripts/imagenet/` train to completion with no issues. 