### PR TITLE
Rename `*_config` to just `config`

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -16,21 +16,21 @@ class ImageNetDataSet(Dataset):
     sample_types = {'image': 'float32', 'label': 'uint8'}
     target_keys = ['label']
 
-    def __init__(self, df_images, dataset_config):
+    def __init__(self, df_images, config):
         """Init
 
-        `dataset_config` must contain the following keys:
+        `config` must contain the following keys:
         - int height: height to reshape the images to
         - int width: width to reshape the images to
 
-        :param dataset_config: specifies the configuration of the dataset
-        :type dataset_config: dict
+        :param config: specifies the configuration of the dataset
+        :type config: dict
         :param df_images: holds the filepath to the input image ('fpath_image')
          and the target label for the image ('label')
         :type df_images: pandas.DataFrame
         """
 
-        validate_config(dataset_config, self.required_config_keys)
+        validate_config(config, self.required_config_keys)
 
         if set(df_images.columns) < {'fpath_image', 'label'}:
             msg = (
@@ -40,7 +40,7 @@ class ImageNetDataSet(Dataset):
             raise KeyError(msg)
 
         self.df_images = df_images
-        self.config = dataset_config
+        self.config = config
         self.df_images['label'] = (
             self.df_images['label'].astype(self.sample_types['label'])
         )

--- a/dl_playground/networks/pytorch/object_classification/alexnet.py
+++ b/dl_playground/networks/pytorch/object_classification/alexnet.py
@@ -17,21 +17,21 @@ class AlexNet(Module):
 
     required_config_keys = {'n_channels', 'n_classes'}
 
-    def __init__(self, network_config):
+    def __init__(self, config):
         """Init
 
-        `network_config` must contain the following keys:
+        `config` must contain the following keys:
         - int n_channels: number of channels of the input
         - int n_classes: number of classes in the output layer
 
-        :param network_config: specifies the configuration for the network
-        :type network_config: dict
+        :param config: specifies the configuration for the network
+        :type config: dict
         """
 
         super().__init__()
 
-        validate_config(network_config, self.required_config_keys)
-        self.network_config = network_config
+        validate_config(config, self.required_config_keys)
+        self.config = config
         self._set_layers()
 
     def _set_layers(self):
@@ -41,8 +41,8 @@ class AlexNet(Module):
         (self.linear[1-3]) in place.
         """
 
-        n_channels = self.network_config['n_channels']
-        n_classes = self.network_config['n_classes']
+        n_channels = self.config['n_channels']
+        n_classes = self.config['n_classes']
 
         self.conv1 = Conv2d(
             in_channels=n_channels, out_channels=96,

--- a/dl_playground/networks/tf/object_classification/alexnet.py
+++ b/dl_playground/networks/tf/object_classification/alexnet.py
@@ -19,21 +19,21 @@ class AlexNet(object):
 
     required_config_keys = {'height', 'width', 'n_channels', 'n_classes'}
 
-    def __init__(self, network_config):
+    def __init__(self, config):
         """Init
 
-        `network_config` must contain the following keys:
+        `config` must contain the following keys:
         - int height: height of the input to the network
         - int width: width of the input to the network
         - int n_channels: number of channels of the input
         - int n_classes: number of classes in the output layer
 
-        :param network_config: specifies the configuration for the network
-        :type network_config: dict
+        :param config: specifies the configuration for the network
+        :type config: dict
         """
 
-        validate_config(network_config, self.required_config_keys)
-        self.network_config = network_config
+        validate_config(config, self.required_config_keys)
+        self.config = config
 
     def forward(self):
         """Return the inputs and outputs representing a forward pass of AlexNet
@@ -46,10 +46,10 @@ class AlexNet(object):
         :rtype: tuple(tensorflow.Tensor)
         """
 
-        height = self.network_config['height']
-        width = self.network_config['width']
-        n_channels = self.network_config['n_channels']
-        n_classes = self.network_config['n_classes']
+        height = self.config['height']
+        width = self.config['width']
+        n_channels = self.config['n_channels']
+        n_classes = self.config['n_classes']
 
         inputs = Input(shape=(height, width, n_channels), name='image')
 

--- a/tests/integration_tests/training/pytorch/test_model.py
+++ b/tests/integration_tests/training/pytorch/test_model.py
@@ -36,7 +36,7 @@ class TestModel(object):
             shuffle=True, num_workers=4
         )
 
-        alexnet = AlexNet(network_config={'n_channels': 3, 'n_classes': 1000})
+        alexnet = AlexNet(config={'n_channels': 3, 'n_classes': 1000})
         model = Model(network=alexnet)
 
         assert not model._compiled

--- a/tests/unit_tests/applications/pytorch/object_classification/test_alexnet.py
+++ b/tests/unit_tests/applications/pytorch/object_classification/test_alexnet.py
@@ -87,7 +87,7 @@ class TestAlexNet(object):
         alexnet = AlexNet(network_config)
 
         assert alexnet.required_config_keys == {'n_channels', 'n_classes'}
-        assert id(network_config) == id(alexnet.network_config)
+        assert id(network_config) == id(alexnet.config)
         assert mock_validate_config.call_count == 1
         mock_validate_config.assert_called_with(
             network_config, AlexNet.required_config_keys
@@ -106,7 +106,7 @@ class TestAlexNet(object):
         """
 
         alexnet = MagicMock()
-        alexnet.network_config = network_config
+        alexnet.config = network_config
         alexnet._set_layers = AlexNet._set_layers
 
         layer_names = [
@@ -141,7 +141,7 @@ class TestAlexNet(object):
         """
 
         alexnet = MagicMock()
-        alexnet.network_config = network_config
+        alexnet.config = network_config
         alexnet.forward = AlexNet.forward
 
         inputs = torch.randn((1, 227, 227, 3))

--- a/tests/unit_tests/applications/tf/object_classification/test_alexnet.py
+++ b/tests/unit_tests/applications/tf/object_classification/test_alexnet.py
@@ -48,7 +48,7 @@ class TestAlexNet(object):
         )
 
         alexnet = AlexNet(network_config)
-        assert alexnet.network_config == network_config
+        assert alexnet.config == network_config
         mock_validate_config.assert_called_once_with(
             network_config, AlexNet.required_config_keys
         )
@@ -64,7 +64,7 @@ class TestAlexNet(object):
 
         alexnet = MagicMock()
         alexnet.forward = AlexNet.forward
-        alexnet.network_config = network_config
+        alexnet.config = network_config
         inputs, outputs = alexnet.forward(self=alexnet)
 
         assert isinstance(inputs, tf.Tensor)


### PR DESCRIPTION
This removes a bit of the redundancy; calling the attribute of the `Network`
that holds the config `network_config` is a bit redundant.