### PR TITLE
Add ability to train with a YAML config

### DIFF
--- a/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
@@ -26,7 +26,7 @@ dataset:
         num_workers: 4
     val_loader:
         batch_size: 128
-        shuffle: True
+        shuffle: False
         num_workers: 2
 network:
     importpath: networks.pytorch.object_classification.alexnet.AlexNet

--- a/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
@@ -1,0 +1,44 @@
+dataset:
+    importpath: datasets.imagenet_dataset.ImageNetDataSet
+    init_params: 
+        config:
+            height: 227
+            width: 227
+    transformations:
+        - datasets.ops.per_image_standardization:
+            sample_keys:
+                value:
+                    - 'image'
+        - torchvision.transforms.functional.to_tensor:
+            sample_keys:
+                value: 
+                    - 'image'
+        - torch.tensor:
+            sample_keys:
+                value: 
+                    - 'label'
+            dtype:
+                import: true
+                value: 'torch.long'
+    train_loader:
+        batch_size: 128
+        shuffle: True
+        num_workers: 4
+    val_loader:
+        batch_size: 128
+        shuffle: True
+        num_workers: 2
+network:
+    importpath: networks.pytorch.object_classification.alexnet.AlexNet
+    init_params:
+        config:
+            n_channels: 3
+            n_classes: 1000
+trainer:
+    importpath: training.pytorch.imagenet_trainer.ImageNetTrainer
+    init_params:
+        config:
+            optimizer: 'Adam'
+            loss: 'CrossEntropyLoss'
+            batch_size: 128
+            n_epochs: 10

--- a/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
@@ -1,0 +1,41 @@
+dataset:
+    importpath: datasets.imagenet_dataset.ImageNetDataSet
+    init_params:
+        config:
+            height: 227
+            width: 227
+    transformations:
+        - tensorflow.one_hot:
+            sample_keys:
+                value:
+                    - 'label'
+            depth:
+                value: 1000
+        - tensorflow.image.per_image_standardization:
+            sample_keys:
+                value:
+                    - 'image'
+    train_loader:
+        batch_size: 128
+        shuffle: True
+        n_workers: 4
+    val_loader:
+        batch_size: 128
+        shuffle: False
+        n_workers: 2
+network:
+    importpath: networks.tf.object_classification.alexnet.AlexNet
+    init_params:
+        config:
+            height: 227
+            width: 227
+            n_channels: 3
+            n_classes: 1000
+trainer:
+    importpath: training.tf.imagenet_trainer.ImageNetTrainer
+    init_params:
+        config:
+            optimizer: 'adam'
+            loss: 'categorical_crossentropy'
+            batch_size: 128
+            n_epochs: 10

--- a/scripts/imagenet/train_alexnet_pytorch.py
+++ b/scripts/imagenet/train_alexnet_pytorch.py
@@ -115,7 +115,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--fpath_config', type=str, required=True,
-        help='Filepath to the training config.'
+        help='Filepath to a training config.'
     )
 
     args = parser.parse_args()

--- a/scripts/imagenet/train_alexnet_pytorch.py
+++ b/scripts/imagenet/train_alexnet_pytorch.py
@@ -28,6 +28,9 @@ FPATH_DF_VAL_SET = os.path.join(
 def get_data_loaders(dataset_spec):
     """Return train and validation data loaders
 
+    :param dataset_spec: specifies how to build the train and validation
+     datasets
+    :type dataset_spec: dict
     :return: loaders of the training and validation data
     :rtype: tuple(torch.utils.data.DataLoader)
     """
@@ -80,6 +83,8 @@ def get_data_loaders(dataset_spec):
 def get_network(network_spec):
     """Return an alexnet model to use during training
 
+    :param network_spec: specifies how to build the AlexNet model
+    :type network_spec: dict
     :return: alexnet model
     :rtype: networks.alexnet_pytorch.AlexNet
     """
@@ -94,6 +99,8 @@ def get_network(network_spec):
 def get_trainer(trainer_spec):
     """Return a trainer to train AlexNet on ImageNet
 
+    :param trainer_spec: specifies how to train the AlexNet on ImageNet
+    :type trainer_spec: dict
     :return: trainer to train alexnet on imagenet
     :rtype: trainers.imagenet_trainer_pytorch.ImageNetTrainer
     """
@@ -110,7 +117,11 @@ def get_trainer(trainer_spec):
 
 
 def parse_args():
-    """Parse command line arguments"""
+    """Parse command line arguments
+
+    :return: namespace holding command line arguments
+    :rtype: argparse.Namespace
+    """
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/scripts/imagenet/train_alexnet_tf.py
+++ b/scripts/imagenet/train_alexnet_tf.py
@@ -22,14 +22,13 @@ FPATH_DF_VAL_SET = os.path.join(
     'metadata_lists', 'df_classification_val_set.csv'
 )
 
-IMAGE_HEIGHT = 227
-IMAGE_WIDTH = 227
-BATCH_SIZE = 128
-
 
 def get_data_loaders(dataset_spec):
     """Return train and validation data loaders
-
+    
+    :param dataset_spec: specifies how to build the train and validation
+     datasets
+    :type dataset_spec: dict
     :return: loaders of the training and validation data
     :rtype: tuple(datasets.tf_data_loader.TFDataLoader)
     """
@@ -73,6 +72,8 @@ def get_data_loaders(dataset_spec):
 def get_network(network_spec):
     """Return an alexnet model to use during training
 
+    :param network_spec: specifies how to build the AlexNet model
+    :type network_spec: dict
     :return: alexnet model
     :rtype: networks.alexnet.AlexNet
     """
@@ -86,7 +87,9 @@ def get_network(network_spec):
 
 def get_trainer(trainer_spec):
     """Return a trainer to train AlexNet on ImageNet
-
+    
+    :param trainer_spec: specifies how to train the AlexNet on ImageNet
+    :type trainer_spec: dict
     :return: trainer to train alexnet on imagenet
     :rtype: trainers.imagenet_trainer_tf.ImageNetTrainer
     """
@@ -99,7 +102,11 @@ def get_trainer(trainer_spec):
 
 
 def parse_args():
-    """Parse command line arguments"""
+    """Parse command line arguments
+
+    :return: namespace holding command line arguments
+    :rtype: argparse.Namespace
+    """
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/setup/environment_cpu.yml
+++ b/setup/environment_cpu.yml
@@ -80,6 +80,7 @@ dependencies:
   - python-dateutil=2.7.3=py35_0
   - pytz=2018.5=py35_0
   - pywavelets=0.5.2=py35h53ec731_0
+  - pyyaml=3.13=py35h14c3975_0
   - qt=5.9.5=h7e424d6_0
   - readline=7.0=ha6073c6_4
   - scikit-image=0.14.0=py35hf484d3e_1
@@ -101,6 +102,7 @@ dependencies:
   - wheel=0.31.1=py35_0
   - wrapt=1.10.11=py35hfdafd39_0
   - xz=5.2.4=h14c3975_4
+  - yaml=0.1.7=had09818_2
   - zlib=1.2.11=ha838bed_2
   - pytorch-cpu=1.0.0=py3.5_cpu_1
   - torchvision-cpu=0.2.1=py_2

--- a/setup/environment_gpu.yml
+++ b/setup/environment_gpu.yml
@@ -80,6 +80,7 @@ dependencies:
   - python-dateutil=2.7.3=py35_0
   - pytz=2018.5=py35_0
   - pywavelets=0.5.2=py35h53ec731_0
+  - pyyaml=3.13=py35h14c3975_0
   - qt=5.9.5=h7e424d6_0
   - readline=7.0=ha6073c6_4
   - scikit-image=0.14.0=py35hf484d3e_1
@@ -101,6 +102,7 @@ dependencies:
   - wheel=0.31.1=py35_0
   - wrapt=1.10.11=py35hfdafd39_0
   - xz=5.2.4=h14c3975_4
+  - yaml=0.1.7=had09818_2
   - zlib=1.2.11=ha838bed_2
   - pytorch=1.0.0=py3.5_cuda9.0.176_cudnn7.4.1_1
   - torchvision=0.2.1=py_2


### PR DESCRIPTION
This PR updates the scripts `scripts/imagenet/train_alexnet_pytorch.py` and `scripts/imagenet/train_alexnet_tf.py` to train based off of a specified config, e.g. the configs at `training/training_configs`.  These are fairly basic right now, and there are still some additional details to be worked out (such as how to specify the training dataframes to use via the config, instead of the scripts). Additionally, I imagine this might be wrapped in some kind of `TrainingJob` or `TrainingRun` class at some point. In the future my hope is that once the code is set up, training can largely be specified via a config, rather than needing to write a separate script. However, I'm deferring this to a future date to see how the code around it develops and to work on higher priority things right now (e.g. pytorch callbacks). 