### PR TITLE
Add use of CallbackList in pytorch Model object

### DIFF
--- a/scripts/imagenet/train_alexnet_pytorch.py
+++ b/scripts/imagenet/train_alexnet_pytorch.py
@@ -105,7 +105,7 @@ def get_trainer(trainer_spec):
     :rtype: trainers.imagenet_trainer_pytorch.ImageNetTrainer
     """
 
-    os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+    os.environ['CUDA_VISIBLE_DEVICES'] = '1'
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     trainer_importpath = trainer_spec['importpath']

--- a/scripts/imagenet/train_alexnet_tf.py
+++ b/scripts/imagenet/train_alexnet_tf.py
@@ -25,7 +25,7 @@ FPATH_DF_VAL_SET = os.path.join(
 
 def get_data_loaders(dataset_spec):
     """Return train and validation data loaders
-    
+
     :param dataset_spec: specifies how to build the train and validation
      datasets
     :type dataset_spec: dict
@@ -87,7 +87,7 @@ def get_network(network_spec):
 
 def get_trainer(trainer_spec):
     """Return a trainer to train AlexNet on ImageNet
-    
+
     :param trainer_spec: specifies how to train the AlexNet on ImageNet
     :type trainer_spec: dict
     :return: trainer to train alexnet on imagenet


### PR DESCRIPTION
This PR adds the use of callbacks into the pytorch `Model` object. It doesn't currently allow for user-specified callbacks; it just uses the default callbacks that `Keras` uses in its `Model` object when `verbose=1` (in the future `verbose` will be a function parameter). So, now when training a pytorch network with the `Model` object, it's possible to get a progress bar similar to what you would get in `Keras`: 

![image](https://user-images.githubusercontent.com/12429170/51077711-069a7200-165f-11e9-82dc-5e04ce95d9cc.png)
