### PR TITLE
Add [save|load]_weights method to pytorch Model

### DIFF
--- a/dl_playground/training/pytorch/model.py
+++ b/dl_playground/training/pytorch/model.py
@@ -180,6 +180,7 @@ class Model(object):
             'steps': n_steps_per_epoch,
             'verbose': True
         })
+        callbacks.set_model(self)
 
         callbacks.on_train_begin()
         for idx_epoch in range(n_epochs):
@@ -203,6 +204,31 @@ class Model(object):
                 epoch_logs['val_loss'] = val_loss
             callbacks.on_epoch_end(idx_epoch, epoch_logs)
         callbacks.on_train_end()
+
+    def load_weights(self, fpath_weights):
+        """Loads all layer weights from the provided `fpath_weights`
+
+        :param fpath_weights: fpath_weights to load the model from
+        :type fpath_weights: str
+        """
+
+        self.network.load_state_dict(torch.load(fpath_weights))
+
+    def save_weights(self, fpath_weights, overwrite=True):
+        """Dumps all layers and weights to the provided `fpath_weights`
+
+        The weights can be loaded into a `Model` with the same topology using
+        the `Model.load_weights` method.
+
+        :param fpath_weights: fpath_weights to save the model to
+        :type fpath_weights: str
+        :param overwrite: overwrite an existing file at `fpath_weights`
+         (if present); only True is currently supported
+        :type overwrite: bool
+        """
+
+        assert overwrite, '`overwrite=False` is not supported!'
+        torch.save(self.network.state_dict(), fpath_weights)
 
     def test_on_batch(self, inputs, targets):
         """Evaluate the model on a single batch of samples

--- a/tests/integration_tests/training/pytorch/test_model.py
+++ b/tests/integration_tests/training/pytorch/test_model.py
@@ -1,5 +1,6 @@
 """Integration tests for training.pytorch.model"""
 
+import tempfile
 from unittest.mock import patch
 
 import torch
@@ -18,8 +19,23 @@ from utils.test_utils import df_images
 class TestModel(object):
     """Tests for Model"""
 
+    def test_load_weights(self):
+        """Test load_weights method
+
+        This tests that a model saved using the `Model.save_weights` method can
+        be loaded using the `Model.load_weights` method.
+        """
+
+        alexnet = AlexNet(config={'n_channels': 3, 'n_classes': 1000})
+        model1 = Model(network=alexnet)
+        model2 = Model(network=alexnet)
+
+        fpath_weights = tempfile.mktemp()
+        model1.save_weights(fpath_weights)
+        model2.load_weights(fpath_weights)
+
     def test_fit_generator(self, df_images):
-        """Test fit_generator_method"""
+        """Test fit_generator method"""
 
         dataset_config = {'height': 227, 'width': 227}
         dataset = ImageNetDataSet(df_images, dataset_config)


### PR DESCRIPTION
This PR adds `Model.save_weights` and `Model.load_weights` methods, namely to support the `keras.callbacks.ModelCheckpoint` callback (see picture below where it's working 🎉 ). In a future PR the `fit_generator` call will be updated to allow for user specified callbacks (the test below was performed manually). 

![screen shot 2019-01-12 at 2 07 50 pm](https://user-images.githubusercontent.com/12429170/51188113-2a91c980-1892-11e9-949b-5b8ec98ab3c8.png)
