### PR TITLE
Add TrainingJob classes

### DIFF
--- a/dl_playground/training/pytorch/training_job.py
+++ b/dl_playground/training/pytorch/training_job.py
@@ -1,0 +1,57 @@
+"""Class for running a specified pytorch training job"""
+
+import pandas as pd
+from torch.utils.data import DataLoader
+
+from training.pytorch.dataset_transformer import PyTorchDataSetTransformer
+from training.training_job import TrainingJob
+from utils.generic_utils import import_object
+
+
+class PyTorchTrainingJob(TrainingJob):
+    """Runs a training job as specified via a config"""
+
+    def _instantiate_dataset(self, set_name):
+        """Return a dataset object to be used as an iterator during training
+
+        The dataset that is returned should be able to be directly passed into
+        the `train` method of whatever trainer class is specified in
+        `self.config`, as either the `train_dataset` or `validation_dataset`
+        argument.
+
+        :param set_name: set to return the dataset for, one of
+         {'train', 'validation'}
+        :type set_name: str
+        :return: two element tuple holding an iterable over the dataset for
+         `set_name`, as well as the number of batches in a single pass over the
+         dataset
+        :rtype: tuple
+        """
+
+        assert set_name in {'train', 'validation'}
+        dataset_spec = self.config['dataset']
+
+        fpath_df_obs_key = 'fpath_df_{}'.format(set_name)
+        if fpath_df_obs_key not in dataset_spec:
+            if set_name == 'train':
+                raise RuntimeError
+            return None, None
+        fpath_df_obs = dataset_spec[fpath_df_obs_key]
+        df_obs = pd.read_csv(fpath_df_obs)
+
+        dataset_importpath = dataset_spec['importpath']
+        DataSet = import_object(dataset_importpath)
+
+        dataset = DataSet(df_obs=df_obs, **dataset_spec['init_params'])
+        if set_name == 'train':
+            transformations = dataset_spec['transformations']
+            transformations = self._parse_transformations(transformations)
+        else:
+            transformations = []
+
+        dataset = PyTorchDataSetTransformer(dataset, transformations)
+        loading_params = dataset_spec['{}_loading_params'.format(set_name)]
+        dataset_gen = DataLoader(dataset, **loading_params)
+        n_batches = len(dataset_gen)
+
+        return dataset_gen, n_batches

--- a/dl_playground/training/tf/training_job.py
+++ b/dl_playground/training/tf/training_job.py
@@ -1,0 +1,56 @@
+"""Class for running a specified tensorflow training job"""
+
+import pandas as pd
+
+from training.training_job import TrainingJob
+from training.tf.data_loader import TFDataLoader
+from utils.generic_utils import import_object
+
+
+class TFTrainingJob(TrainingJob):
+    """Runs a training job as specified via a config"""
+
+    def _instantiate_dataset(self, set_name):
+        """Return a dataset object to be used as an iterator during training
+
+        The dataset that is returned should be able to be directly passed into
+        the `train` method of whatever trainer class is specified in
+        `self.config`, as either the `train_dataset` or `validation_dataset`
+        argument.
+
+        :param set_name: set to return the dataset for, one of
+         {'train', 'validation'}
+        :type set_name: str
+        :return: two element tuple holding an iterable over the dataset for
+         `set_name`, as well as the number of batches in a single pass over the
+         dataset
+        :rtype: tuple
+        """
+
+        assert set_name in {'train', 'validation'}
+        dataset_spec = self.config['dataset']
+
+        fpath_df_obs_key = 'fpath_df_{}'.format(set_name)
+        if fpath_df_obs_key not in dataset_spec:
+            if set_name == 'train':
+                raise RuntimeError
+            return None, None
+        fpath_df_obs = dataset_spec[fpath_df_obs_key]
+        df_obs = pd.read_csv(fpath_df_obs)
+
+        dataset_importpath = dataset_spec['importpath']
+        DataSet = import_object(dataset_importpath)
+
+        dataset = DataSet(df_obs=df_obs, **dataset_spec['init_params'])
+        if set_name == 'train':
+            transformations = dataset_spec['transformations']
+            transformations = self._parse_transformations(transformations)
+        else:
+            transformations = []
+
+        loader = TFDataLoader(dataset, transformations)
+        loading_params = dataset_spec['{}_loading_params'.format(set_name)]
+        dataset_gen = loader.get_infinite_iter(**loading_params)
+        n_batches = len(loader.numpy_dataset) // loading_params['batch_size']
+
+        return dataset_gen, n_batches

--- a/dl_playground/training/training_job.py
+++ b/dl_playground/training/training_job.py
@@ -1,0 +1,144 @@
+"""Class for running a specified training job"""
+
+from utils.generic_utils import import_object, validate_config
+
+
+class TrainingJob(object):
+    """Runs a training job as specified via a config"""
+
+    required_config_keys = {'network', 'trainer', 'dataset'}
+
+    def __init__(self, config):
+        """Init
+
+        The `config` must contain the following keys:
+        - dict network: specifies the network class to train as well as how to
+          build it; see the `_instantiate_network` method for details
+        - dict trainer: specifies the trainer class to train with; see the
+          `_instantiate_trainer` method for details
+        - dict dataset: specifies the training and validation dataset classes
+          to train with, as well as how to load the data from the datasets; see
+          the `_instantiate_dataset` method in child classes for details
+
+        :param config: config file specifying a training job to run
+        :type config: dict
+        """
+
+        validate_config(config, self.required_config_keys)
+        self.config = config
+
+    def _instantiate_dataset(self, set_name):
+        """Return a dataset object to be used as an iterator during training
+
+        The dataset that is returned should be able to be directly passed into
+        the `train` method of whatever trainer class is specified in
+        `self.config`, as either the `train_dataset` or `validation_dataset`
+        argument.
+
+        :param set_name: set to return the dataset for, one of
+         {'train', 'validation'}
+        :type set_name: str
+        """
+
+        raise NotImplementedError
+
+    def _instantiate_network(self):
+        """Return the network object to train
+
+        This relies on the `network` section of `self.config`. This section
+        must contain the following keys:
+        - str importpath: import path to the network class to use for training
+        - dict init_params: parameters to pass directly into the `__init__` of
+          the specified network as keyword arguments
+
+        :return: network for training
+        :rtype: object
+        """
+
+        network_spec = self.config['network']
+
+        network_importpath = network_spec['importpath']
+        Network = import_object(network_importpath)
+        return Network(**network_spec['init_params'])
+
+    def _instantiate_trainer(self):
+        """Return the trainer object that runs training
+
+        This relies on the `trainer` section of `self.config`. This section
+        must contain the following keys:
+        - str importpath: import path to the trainer class to use
+        - dict init_params: parameters to pass directly into the `__init__` of
+          the specified trainer as keyword arguments
+
+        :return: trainer to run training
+        :rtype: object
+        """
+
+        trainer_spec = self.config['trainer']
+
+        trainer_importpath = trainer_spec['importpath']
+        Trainer = import_object(trainer_importpath)
+        return Trainer(**trainer_spec['init_params'])
+
+    def _parse_transformations(self, transformations):
+        """Parse the provided transformations into the expected format
+
+        When passed into the dataset transformers (whose import paths are
+        listed below), `transformations` is expected to be a list of two
+        element tuples, where each tuple contains a transformation function to
+        apply as the first element and function kwargs as the second element.
+        When they are parsed from the config (and passed into this function),
+        they are a list of dictionaries. This function mostly reformats them to
+        the format expected by the following dataset transformer classes:
+        - training.pytorch.dataset_transformer.PyTorchDataSetTransformer
+        - training.tf.data_loader.TFDataLoader
+
+        :param transformations: holds the transformations to apply to each
+         batch of data, where each transformation is specified as a dictionary
+         with the key equal to the importpath of the callable transformation
+         and the value equal to a dictionary holding keyword arguments for the
+         callable
+        :type transformations: list[dict]
+        :return: parsed transformations reformatted for the dataset transformer
+         classes
+        :type transformations: list[tuple]
+        """
+
+        processed_transformations = []
+        for transformation in transformations:
+            assert len(transformation) == 1
+            transformation_fn_importpath = list(transformation.keys())[0]
+            transformation_config = list(transformation.values())[0]
+
+            transformation_fn = import_object(transformation_fn_importpath)
+            processed_transformation_config = {}
+            for param, arguments in transformation_config.items():
+                value = arguments['value']
+                if arguments.get('import'):
+                    value = import_object(value)
+                processed_transformation_config[param] = value
+            processed_transformations.append(
+                (transformation_fn, processed_transformation_config)
+            )
+
+        return processed_transformations
+
+    def run(self):
+        """Run training as specified via `self.config`"""
+
+        network = self._instantiate_network()
+        trainer = self._instantiate_trainer()
+        train_dataset, n_steps_per_epoch = (
+            self._instantiate_dataset(set_name='train')
+        )
+        validation_dataset, n_validation_steps = (
+            self._instantiate_dataset(set_name='validation')
+        )
+
+        trainer.train(
+            network=network,
+            train_dataset=train_dataset,
+            n_steps_per_epoch=n_steps_per_epoch,
+            validation_dataset=validation_dataset,
+            n_validation_steps=n_validation_steps
+        )

--- a/tests/unit_tests/datasets/test_imagenet_dataset.py
+++ b/tests/unit_tests/datasets/test_imagenet_dataset.py
@@ -51,7 +51,7 @@ class TestImageNetDataSet(object):
         assert dataset.df_images.equals(df_images)
         assert dataset.config == dataset_config
         assert dataset.required_config_keys == {'height', 'width'}
-        mock_validate_config.called_once_with(
+        mock_validate_config.assert_called_once_with(
             dataset.config, dataset.required_config_keys
         )
 

--- a/tests/unit_tests/training/pytorch/test_training_job.py
+++ b/tests/unit_tests/training/pytorch/test_training_job.py
@@ -1,0 +1,179 @@
+"""Unit tests for training.pytorch.training_job"""
+
+from unittest.mock import MagicMock
+import pytest
+
+import pandas as pd
+
+from training.pytorch.training_job import PyTorchTrainingJob
+
+
+class TestPyTorchTrainingJob(object):
+    """Tests for PyTorchTrainingJob"""
+
+    def _get_mock_config(self):
+        """Return a mock config to use for a PyTorchTrainingJob
+
+        This is implemented as a callable method (rather than a fixture)
+        because we want to alter it in several of the tests, without it
+        affecting the other tests.
+
+        :return: mock config that includes a 'dataset' key and the
+         configuration necessary to test the _instantiate_dataset method
+        :rtype: dict
+        """
+
+        return {'dataset': {
+            'fpath_df_train': 'fpath/df/train',
+            'fpath_df_validation': 'fpath/df/validation',
+            'importpath': 'path/to/import',
+            'init_params': {'key1': 'value1', 'key2': 'value2'},
+            'transformations': {'key3': 'value3', 'key4': 'value4'},
+            'train_loading_params': {'batch_size': 2},
+            'validation_loading_params': {'batch_size': 4}
+        }}
+
+    def _check_instantiate_dataset(self, training_job, set_name, monkeypatch):
+        """Check the `_instantiate_dataset` method for the provided `set_name`
+
+        This tests two things:
+        - The right functions / classes are used in the method itself
+        - The returned output is as expected
+
+        `pd.read_csv` is mocked to prevent tests from relying on a saved
+        DataFrame.
+
+        :param training_job: mock training job object to test
+         `_instantiate_dataset` against (the `_instantiate_dataset` is not
+         mocked)
+        :type training_job: unittest.mock.MagicMock
+        :param set_name: set to test the method for, one of 'train',
+         'validation'
+        :type set_name: str
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_read_csv = MagicMock()
+        mock_read_csv.return_value = 'return_from_read_csv'
+        monkeypatch.setattr(pd, 'read_csv', mock_read_csv)
+
+        MockDataSet = MagicMock()
+        MockDataSet.return_value = 'return_from_dataset_init'
+        mock_import_object = MagicMock()
+        mock_import_object.return_value = MockDataSet
+        monkeypatch.setattr(
+            'training.pytorch.training_job.import_object', mock_import_object
+        )
+
+        mock_transformer = MagicMock()
+        mock_transformer.return_value = 'return_from_mock_transformer'
+        monkeypatch.setattr(
+            'training.pytorch.training_job.PyTorchDataSetTransformer',
+            mock_transformer
+        )
+
+        mock_loader = MagicMock()
+        mock_loader_return = MagicMock()
+        mock_loader_return.__len__ = MagicMock()
+        mock_loader_return.__len__.return_value = 10
+        mock_loader.return_value = mock_loader_return
+        monkeypatch.setattr(
+            'training.pytorch.training_job.DataLoader', mock_loader
+        )
+
+        dataset_gen, n_batches = training_job._instantiate_dataset(
+            self=training_job, set_name=set_name
+        )
+
+        assert dataset_gen == mock_loader_return
+        assert n_batches == 10
+        if set_name == 'train':
+            mock_read_csv.assert_called_once_with('fpath/df/train')
+            training_job._parse_transformations.assert_called_once_with(
+                {'key3': 'value3', 'key4': 'value4'}
+            )
+            mock_transformer.assert_called_once_with(
+                'return_from_dataset_init', 'return_from_parse_transformations'
+            )
+            mock_loader.assert_called_once_with(
+                'return_from_mock_transformer', batch_size=2
+            )
+        else:
+            mock_read_csv.assert_called_once_with('fpath/df/validation')
+            mock_transformer.assert_called_once_with(
+                'return_from_dataset_init', []
+            )
+            mock_loader.assert_called_once_with(
+                'return_from_mock_transformer', batch_size=4
+            )
+
+        mock_import_object.assert_called_once_with('path/to/import')
+        MockDataSet.assert_called_once_with(
+            df_obs='return_from_read_csv', key1='value1', key2='value2'
+        )
+
+    def test_instantiate_dataset__errors(self):
+        """Test _instantiate_dataset method when errors are expected
+
+        Errors are expected in two cases:
+        - When `set_name` is not one of 'train' or 'validation'
+          (AssertionError)
+        - When `set_name==train` and there is no `fpath_df_train` in the
+          `TFTrainingJob.config['dataset']` (RunTimeError)
+        """
+
+        training_job = MagicMock()
+        training_job.config = self._get_mock_config()
+        training_job._instantiate_dataset = (
+            PyTorchTrainingJob._instantiate_dataset
+        )
+
+        for bad_set_name in ['test', 'val', 't']:
+            with pytest.raises(AssertionError):
+                training_job._instantiate_dataset(
+                    self=training_job, set_name=bad_set_name
+                )
+
+        del training_job.config['dataset']['fpath_df_train']
+        with pytest.raises(RuntimeError):
+            training_job._instantiate_dataset(
+                self=training_job, set_name='train'
+            )
+
+    def test_instantiate_dataset__no_errors(self, monkeypatch):
+        """Test _instantiate_dataset method when no errors are expected
+
+        This tests two things via the _check_instantiate_dataset method:
+        - The right functions / classes are used in the method itself
+        - The returned output is as expected
+
+        It checks these for when `set_name` is 'train' and 'validation'.
+        Additionally, this tests that when there is no `fpath_df_validation`
+        specified, there is no dataset returned.
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        training_job = MagicMock()
+        training_job.config = self._get_mock_config()
+        training_job._parse_transformations = MagicMock()
+        training_job._parse_transformations.return_value = (
+            'return_from_parse_transformations'
+        )
+        training_job._instantiate_dataset = (
+            PyTorchTrainingJob._instantiate_dataset
+        )
+
+        for set_name in ('train', 'validation'):
+            self._check_instantiate_dataset(
+                training_job, set_name, monkeypatch
+            )
+
+        del training_job.config['dataset']['fpath_df_validation']
+        dataset_gen, n_batches = training_job._instantiate_dataset(
+            self=training_job, set_name='validation'
+        )
+        assert dataset_gen is None
+        assert n_batches is None

--- a/tests/unit_tests/training/test_training_job.py
+++ b/tests/unit_tests/training/test_training_job.py
@@ -1,0 +1,161 @@
+"""Unit tests for training.training_job"""
+
+from unittest.mock import call, MagicMock
+import pytest
+
+from training.training_job import TrainingJob
+
+
+class TestTrainingJob(object):
+    """Tests for TrainingJob"""
+
+    def test_init(self, monkeypatch):
+        """Test __init__ method
+
+        This test tests two things:
+        - All attributes are set correctly in the __init__
+        - The `validate_config` function is called from the init with the
+          expected arguments
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_validate_config = MagicMock()
+        monkeypatch.setattr(
+            'training.training_job.validate_config', mock_validate_config
+        )
+
+        mock_config = MagicMock()
+        training_job = TrainingJob(mock_config)
+        assert id(training_job.config) == id(mock_config)
+        assert (
+            training_job.required_config_keys ==
+            {'network', 'trainer', 'dataset'}
+        )
+        mock_validate_config.assert_called_once_with(
+            mock_config, training_job.required_config_keys
+        )
+
+    def test_instantiate_network(self, monkeypatch):
+        """Test _instantiate_network method
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_config = {
+            'network': {
+                'importpath': 'path.to.network.import',
+                'init_params': {
+                    'config': {'key1': 'value1', 'key2': 'value2'},
+                    'test': 0,
+                    'params': (1, 2, 3)
+                }
+            }
+        }
+
+        mock_import_object = MagicMock()
+        mock_network_class = MagicMock()
+        mock_import_object.return_value = mock_network_class
+        monkeypatch.setattr(
+            'training.training_job.import_object', mock_import_object
+        )
+
+        training_job = MagicMock()
+        training_job._instantiate_network = TrainingJob._instantiate_network
+        training_job.config = mock_config
+
+        training_job._instantiate_network(self=training_job)
+        mock_import_object.assert_called_once_with('path.to.network.import')
+        mock_network_class.assert_called_once_with(
+            test=0, params=(1, 2, 3),
+            config={'key1': 'value1', 'key2': 'value2'}
+        )
+
+    def test_instantiate_trainer(self, monkeypatch):
+        """Test _instantiate_trainer method
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_config = {
+            'trainer': {
+                'importpath': 'path.to.trainer.import',
+                'init_params': {
+                    'param0': 0,
+                    'param1': (2, 4, 6),
+                    'param2': {'key3': 'value3'}
+                }
+            }
+        }
+
+        mock_import_object = MagicMock()
+        mock_trainer_class = MagicMock()
+        mock_import_object.return_value = mock_trainer_class
+        monkeypatch.setattr(
+            'training.training_job.import_object', mock_import_object
+        )
+
+        training_job = MagicMock()
+        training_job._instantiate_trainer = TrainingJob._instantiate_trainer
+        training_job.config = mock_config
+
+        training_job._instantiate_trainer(self=training_job)
+        mock_import_object.assert_called_once_with('path.to.trainer.import')
+        mock_trainer_class.assert_called_once_with(
+            param0=0, param1=(2, 4, 6), param2={'key3': 'value3'}
+        )
+
+    def test_parse_transformations(self, monkeypatch):
+        """Test _parse_transformations method
+
+        This tests two things:
+        - That an AssertionError is raised if any of the individual elements in
+          the `transformations` argument passed to the _parse_transformations
+          method are not of length 1
+        - That the returned output is as exepcted
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        training_job = MagicMock()
+        training_job._parse_transformations = (
+            TrainingJob._parse_transformations
+        )
+        mock_import_object = MagicMock()
+        mock_import_object.return_value = 'import_object_return'
+        monkeypatch.setattr(
+            'training.training_job.import_object', mock_import_object
+        )
+
+        with pytest.raises(AssertionError):
+            processed_transformations = training_job._parse_transformations(
+                self=training_job,
+                transformations=[{'key1_OK': {}, 'key2_NOT_OK': {}}]
+            )
+        assert mock_import_object.call_count == 0
+
+        transformations = [
+            {'transformation1':
+             {'sample_keys': {'value': ['image', 'label']}}},
+            {'transformation2':
+             {'sample_keys': {'value': ['image']},
+              'dtype': {'value': 'torch.long', 'import': True}}}
+        ]
+
+        processed_transformations = training_job._parse_transformations(
+            self=training_job, transformations=transformations
+        )
+        assert mock_import_object.call_count == 3
+        mock_import_object.assert_has_calls([
+            call('transformation1'), call('transformation2'),
+            call('torch.long')
+        ])
+        assert processed_transformations == [
+            ('import_object_return', {'sample_keys': ['image', 'label']}),
+            ('import_object_return',
+             {'sample_keys': ['image'], 'dtype': 'import_object_return'})
+        ]

--- a/tests/unit_tests/training/tf/test_training_job.py
+++ b/tests/unit_tests/training/tf/test_training_job.py
@@ -1,0 +1,172 @@
+"""Unit tests for training.tf.training_job"""
+
+from unittest.mock import create_autospec, MagicMock
+import pytest
+
+import pandas as pd
+
+from training.tf.data_loader import TFDataLoader
+from training.tf.training_job import TFTrainingJob
+
+
+class TestTFTrainingJob(object):
+    """Tests for TFTrainingJob"""
+
+    def _get_mock_config(self):
+        """Return a mock config to use for a TFTrainingJob
+
+        This is implemented as a callable method (rather than a fixture)
+        because we want to alter it in several of the tests, without it
+        affecting the other tests.
+
+        :return: mock config that includes a 'dataset' key and the
+         configuration necessary to test the _instantiate_dataset method
+        :rtype: dict
+        """
+
+        return {'dataset': {
+            'fpath_df_train': 'fpath/df/train',
+            'fpath_df_validation': 'fpath/df/validation',
+            'importpath': 'path/to/import',
+            'init_params': {'key1': 'value1', 'key2': 'value2'},
+            'transformations': {'key3': 'value3', 'key4': 'value4'},
+            'train_loading_params': {'batch_size': 2},
+            'validation_loading_params': {'batch_size': 4}
+        }}
+
+    def _check_instantiate_dataset(self, training_job, set_name, monkeypatch):
+        """Check the `_instantiate_dataset` method for the provided `set_name`
+
+        This tests two things:
+        - The right functions / classes are used in the method itself
+        - The returned output is as expected
+
+        `pd.read_csv` is mocked to prevent tests from relying on a saved
+        DataFrame.
+
+        :param training_job: mock training job object to test
+         `_instantiate_dataset` against (the `_instantiate_dataset` is not
+         mocked)
+        :type training_job: unittest.mock.MagicMock
+        :param set_name: set to test the method for, one of 'train',
+         'validation'
+        :type set_name: str
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_read_csv = MagicMock()
+        mock_read_csv.return_value = 'return_from_read_csv'
+        monkeypatch.setattr(pd, 'read_csv', mock_read_csv)
+
+        MockDataSet = MagicMock()
+        MockDataSet.return_value = 'return_from_dataset_init'
+        mock_import_object = MagicMock()
+        mock_import_object.return_value = MockDataSet
+        monkeypatch.setattr(
+            'training.tf.training_job.import_object', mock_import_object
+        )
+
+        mock_numpy_dataset = MagicMock()
+        mock_numpy_dataset.__len__ = MagicMock()
+        mock_numpy_dataset.__len__.return_value = 10
+        mock_loader = create_autospec(
+            TFDataLoader, numpy_dataset=mock_numpy_dataset
+        )
+        mock_loader.get_infinite_iter.return_value = (
+            'return_from_get_infinite_iter'
+        )
+        MockTFDataLoader = MagicMock()
+        MockTFDataLoader.return_value = mock_loader
+        monkeypatch.setattr(
+            'training.tf.training_job.TFDataLoader', MockTFDataLoader
+        )
+
+        dataset_gen, n_batches = training_job._instantiate_dataset(
+            self=training_job, set_name=set_name
+        )
+
+        assert dataset_gen == 'return_from_get_infinite_iter'
+        if set_name == 'train':
+            assert n_batches == 5
+            mock_read_csv.assert_called_once_with('fpath/df/train')
+            training_job._parse_transformations.assert_called_once_with(
+                {'key3': 'value3', 'key4': 'value4'}
+            )
+            MockTFDataLoader.assert_called_once_with(
+                'return_from_dataset_init', 'return_from_parse_transformations'
+            )
+            mock_loader.get_infinite_iter.assert_called_once_with(batch_size=2)
+        else:
+            assert n_batches == 2
+            mock_read_csv.assert_called_once_with('fpath/df/validation')
+            MockTFDataLoader.assert_called_once_with(
+                'return_from_dataset_init', []
+            )
+            mock_loader.get_infinite_iter.assert_called_once_with(batch_size=4)
+
+        mock_import_object.assert_called_once_with('path/to/import')
+        MockDataSet.assert_called_once_with(
+            df_obs='return_from_read_csv', key1='value1', key2='value2'
+        )
+
+    def test_instantiate_dataset__errors(self):
+        """Test _instantiate_dataset method when errors are expected
+
+        Errors are expected in two cases:
+        - When `set_name` is not one of 'train' or 'validation'
+          (AssertionError)
+        - When `set_name==train` and there is no `fpath_df_train` in the
+          `TFTrainingJob.config['dataset']` (RunTimeError)
+        """
+
+        training_job = MagicMock()
+        training_job.config = self._get_mock_config()
+        training_job._instantiate_dataset = TFTrainingJob._instantiate_dataset
+
+        for bad_set_name in ['test', 'val', 't']:
+            with pytest.raises(AssertionError):
+                training_job._instantiate_dataset(
+                    self=training_job, set_name=bad_set_name
+                )
+
+        del training_job.config['dataset']['fpath_df_train']
+        with pytest.raises(RuntimeError):
+            training_job._instantiate_dataset(
+                self=training_job, set_name='train'
+            )
+
+    def test_instantiate_dataset__no_errors(self, monkeypatch):
+        """Test _instantiate_dataset method when no errors are expected
+
+        This tests two things via the _check_instantiate_dataset method:
+        - The right functions / classes are used in the method itself
+        - The returned output is as expected
+
+        It checks these for when `set_name` is 'train' and 'validation'.
+        Additionally, this tests that when there is no `fpath_df_validation`
+        specified, there is no dataset returned.
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        training_job = MagicMock()
+        training_job.config = self._get_mock_config()
+        training_job._parse_transformations = MagicMock()
+        training_job._parse_transformations.return_value = (
+            'return_from_parse_transformations'
+        )
+        training_job._instantiate_dataset = TFTrainingJob._instantiate_dataset
+
+        for set_name in ('train', 'validation'):
+            self._check_instantiate_dataset(
+                training_job, set_name, monkeypatch
+            )
+
+        del training_job.config['dataset']['fpath_df_validation']
+        dataset_gen, n_batches = training_job._instantiate_dataset(
+            self=training_job, set_name='validation'
+        )
+        assert dataset_gen is None
+        assert n_batches is None


### PR DESCRIPTION
This PR adds a `TrainingJob` class, along with pytorch and tensorflow specific versions (for slight differences that arise during training). It also adds unit tests for these classes (with integration tests to come in a future PR). These classes will eventually replace all of the parsing logic that happens in the `scripts/imagenet/train_imagenet_pytorch.py` and `scripts/imagenet/train_imagenet_tf.py` scripts. 