### PR TITLE
Integration testing for TrainingJob classes

### DIFF
--- a/dl_playground/constants.py
+++ b/dl_playground/constants.py
@@ -1,0 +1,5 @@
+"""Constants"""
+
+import os
+
+DIRPATH_DLP = os.path.dirname(__file__)

--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -16,7 +16,7 @@ class ImageNetDataSet(Dataset):
     sample_types = {'image': 'float32', 'label': 'uint8'}
     target_keys = ['label']
 
-    def __init__(self, df_images, config):
+    def __init__(self, df_obs, config):
         """Init
 
         `config` must contain the following keys:
@@ -25,37 +25,37 @@ class ImageNetDataSet(Dataset):
 
         :param config: specifies the configuration of the dataset
         :type config: dict
-        :param df_images: holds the filepath to the input image ('fpath_image')
+        :param df_obs: holds the filepath to the input image ('fpath_image')
          and the target label for the image ('label')
-        :type df_images: pandas.DataFrame
+        :type df_obs: pandas.DataFrame
         """
 
         validate_config(config, self.required_config_keys)
 
-        if set(df_images.columns) < {'fpath_image', 'label'}:
+        if set(df_obs.columns) < {'fpath_image', 'label'}:
             msg = (
-                'df_images must have an \'fpath_image\' and \'label\' '
+                'df_obs must have an \'fpath_image\' and \'label\' '
                 'column, and only {} columns were given.'
-            ).format(df_images.columns)
+            ).format(df_obs.columns)
             raise KeyError(msg)
 
-        self.df_images = df_images
+        self.df_obs = df_obs
         self.config = config
-        self.df_images['label'] = (
-            self.df_images['label'].astype(self.sample_types['label'])
+        self.df_obs['label'] = (
+            self.df_obs['label'].astype(self.sample_types['label'])
         )
 
     def __getitem__(self, idx):
-        """Return the image, label pair at index `idx` from `self.df_images`
+        """Return the image, label pair at index `idx` from `self.df_obs`
 
         :return: dict with keys:
         - numpy.ndarray image: pixel data loaded from the `fpath_image` at
-          index `idx` of `self.df_images`
+          index `idx` of `self.df_obs`
         - int label: class label assigned to the returned image
         :rtype: dict
         """
 
-        fpath_image = self.df_images.loc[idx, 'fpath_image']
+        fpath_image = self.df_obs.loc[idx, 'fpath_image']
         image = imageio.imread(fpath_image)
         if image.ndim == 2:
             image = np.expand_dims(image, -1)
@@ -68,7 +68,7 @@ class ImageNetDataSet(Dataset):
         image = resize(image, output_shape=target_shape)
         image = image.astype(self.sample_types['image'])
 
-        label = np.array(self.df_images.loc[idx, 'label'])
+        label = np.array(self.df_obs.loc[idx, 'label'])
         assert label.dtype == self.sample_types['label']
 
         sample = {'image': image, 'label': label}
@@ -82,7 +82,7 @@ class ImageNetDataSet(Dataset):
         :rtype: int
         """
 
-        return len(self.df_images)
+        return len(self.df_obs)
 
     def as_generator(self, shuffle=False, n_workers=0):
         """Return a generator that yields the entire dataset once

--- a/dl_playground/training/pytorch/imagenet_trainer.py
+++ b/dl_playground/training/pytorch/imagenet_trainer.py
@@ -10,30 +10,30 @@ class ImageNetTrainer(object):
 
     required_config_keys = {'batch_size', 'loss', 'n_epochs', 'optimizer'}
 
-    def __init__(self, trainer_config):
+    def __init__(self, config):
         """Init
 
-        trainer_config must contain the following keys:
+        config must contain the following keys:
         - str optimizer: optimizer to use when training the network
         - str loss: loss function to use when training the network
         - int batch_size: batch size to use during training
         - int n_epochs: number of epochs to train for
 
-        trainer_config can addtionally optionally contain the following keys:
+        config can addtionally optionally contain the following keys:
         - str device: device to train the model on, e.g. 'cuda:0'; defaults to
           'cpu'
 
-        :param trainer_config: specifies the configuration of the trainer
-        :type trainer_config: dict
+        :param config: specifies the configuration of the trainer
+        :type config: dict
         """
 
-        validate_config(trainer_config, self.required_config_keys)
+        validate_config(config, self.required_config_keys)
 
-        self.optimizer = trainer_config['optimizer']
-        self.loss = trainer_config['loss']
-        self.batch_size = trainer_config['batch_size']
-        self.n_epochs = trainer_config['n_epochs']
-        self.device = trainer_config.get('device')
+        self.optimizer = config['optimizer']
+        self.loss = config['loss']
+        self.batch_size = config['batch_size']
+        self.n_epochs = config['n_epochs']
+        self.device = config.get('device')
 
     def train(self, network, train_dataset, n_steps_per_epoch,
               validation_dataset=None, n_validation_steps=None):

--- a/dl_playground/training/pytorch/training_job.py
+++ b/dl_playground/training/pytorch/training_job.py
@@ -52,6 +52,6 @@ class PyTorchTrainingJob(TrainingJob):
         dataset = PyTorchDataSetTransformer(dataset, transformations)
         loading_params = dataset_spec['{}_loading_params'.format(set_name)]
         dataset_gen = DataLoader(dataset, **loading_params)
-        n_batches = len(dataset_gen)
+        n_batches = len(dataset) // loading_params['batch_size']
 
         return dataset_gen, n_batches

--- a/dl_playground/training/tf/imagenet_trainer.py
+++ b/dl_playground/training/tf/imagenet_trainer.py
@@ -10,25 +10,25 @@ class ImageNetTrainer(object):
 
     required_config_keys = {'batch_size', 'loss', 'n_epochs', 'optimizer'}
 
-    def __init__(self, trainer_config):
+    def __init__(self, config):
         """Init
 
-        trainer_config must contain the following keys:
+        config must contain the following keys:
         - str optimizer: optimizer to use when training the network
         - str loss: loss function to use when training the network
         - int batch_size: batch size to use during training
         - int n_epochs: number of epochs to train for
 
-        :param trainer_config: specifies the configuration of the trainer
-        :type trainer_config: dict
+        :param config: specifies the configuration of the trainer
+        :type config: dict
         """
 
-        validate_config(trainer_config, self.required_config_keys)
+        validate_config(config, self.required_config_keys)
 
-        self.optimizer = trainer_config['optimizer']
-        self.loss = trainer_config['loss']
-        self.batch_size = trainer_config['batch_size']
-        self.n_epochs = trainer_config['n_epochs']
+        self.optimizer = config['optimizer']
+        self.loss = config['loss']
+        self.batch_size = config['batch_size']
+        self.n_epochs = config['n_epochs']
 
     def train(self, network, train_dataset, n_steps_per_epoch,
               validation_dataset=None, n_validation_steps=None):

--- a/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
@@ -1,4 +1,6 @@
 dataset:
+    fpath_df_train: /data/imagenet/from_access_links/metadata_lists/df_classification_train_set.csv
+    fpath_df_validation: /data/imagenet/from_access_links/metadata_lists/df_classification_validation_set.csv
     importpath: datasets.imagenet_dataset.ImageNetDataSet
     init_params: 
         config:
@@ -20,11 +22,11 @@ dataset:
             dtype:
                 import: true
                 value: 'torch.long'
-    train_loader:
+    train_loading_params:
         batch_size: 128
         shuffle: True
         num_workers: 4
-    val_loader:
+    validation_loading_params:
         batch_size: 128
         shuffle: False
         num_workers: 2

--- a/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
@@ -1,4 +1,6 @@
 dataset:
+    fpath_df_train: /data/imagenet/from_access_links/metadata_lists/df_classification_train_set.csv
+    fpath_df_validation: /data/imagenet/from_access_links/metadata_lists/df_classification_validation_set.csv
     importpath: datasets.imagenet_dataset.ImageNetDataSet
     init_params:
         config:
@@ -15,11 +17,11 @@ dataset:
             sample_keys:
                 value:
                     - 'image'
-    train_loader:
+    train_loading_params:
         batch_size: 128
         shuffle: True
         n_workers: 4
-    val_loader:
+    validation_loading_params:
         batch_size: 128
         shuffle: False
         n_workers: 2

--- a/tests/integration_tests/training/__init__.py
+++ b/tests/integration_tests/training/__init__.py
@@ -1,1 +1,1 @@
-"""Integration tests for trainers"""
+"""Integration tests for training"""

--- a/tests/integration_tests/training/pytorch/__init__.py
+++ b/tests/integration_tests/training/pytorch/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for pytorch training"""

--- a/tests/integration_tests/training/pytorch/test_training_job.py
+++ b/tests/integration_tests/training/pytorch/test_training_job.py
@@ -1,0 +1,125 @@
+"""Integration tests for training.pytorch.training_job"""
+
+import os
+import pytest
+import tempfile
+
+import torch
+from torch.utils.data import DataLoader
+from torchvision.transforms.functional import to_tensor
+import yaml
+
+from constants import DIRPATH_DLP
+from datasets.ops import per_image_standardization
+from training.pytorch.imagenet_trainer import ImageNetTrainer
+from networks.pytorch.object_classification.alexnet import AlexNet
+from training.pytorch.training_job import PyTorchTrainingJob
+from utils.test_utils import df_images
+
+
+class TestPyTorchTrainingJob(object):
+    """Tests for PyTorchTrainingJob"""
+
+    @pytest.fixture(scope='class')
+    def fpath_df_images(self, df_images):
+        """Return df_images saved to a temporary file
+
+        :return: filepath to saved df_images
+        :rtype: str
+        """
+
+        df_images = df_images.copy()
+
+        fpath_df_images = tempfile.mkstemp()[1]
+        df_images.to_csv(fpath_df_images, index=False)
+        yield fpath_df_images
+
+    @pytest.fixture(scope='class')
+    def config(self, fpath_df_images):
+        """Return a `config` that specifies the training job
+
+        :return: config file that specifies a PyTorch training job
+        :rtype: dict
+        """
+
+        fpath_config = os.path.join(
+            DIRPATH_DLP, 'training', 'training_configs',
+            'alexnet_imagenet_pytorch.yml'
+        )
+        with open(fpath_config, 'r') as f:
+            job_config = yaml.load(f)
+        job_config['dataset']['fpath_df_train'] = fpath_df_images
+        job_config['dataset']['train_loading_params']['batch_size'] = 2
+        job_config['dataset']['fpath_df_validation'] = fpath_df_images
+        job_config['dataset']['validation_loading_params']['batch_size'] = 1
+
+        return job_config
+
+    def test_instantiate_dataset(self, config):
+        """Test _instantiate_dataset class
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = PyTorchTrainingJob(config)
+        dataset, n_batches = job._instantiate_dataset(set_name='train')
+        assert n_batches == 1
+        assert isinstance(dataset, DataLoader)
+
+        dataset, n_batches = job._instantiate_dataset(set_name='validation')
+        assert n_batches == 3
+        assert isinstance(dataset, DataLoader)
+
+    def test_instantiate_network(self, config):
+        """Test _instantiate_network class
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = PyTorchTrainingJob(config)
+        network = job._instantiate_network()
+        assert isinstance(network, AlexNet)
+        assert network.config['n_channels'] == 3
+        assert network.config['n_classes'] == 1000
+
+    def test_instantiate_trainer(self, config):
+        """Test _instantiate_trainer class
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = PyTorchTrainingJob(config)
+        trainer = job._instantiate_trainer()
+        assert isinstance(trainer, ImageNetTrainer)
+        assert trainer.optimizer == 'Adam'
+        assert trainer.loss == 'CrossEntropyLoss'
+        assert trainer.batch_size == 128
+        assert trainer.n_epochs == 10
+        assert trainer.device is None
+
+    def test_parse_transformations(self, config):
+        """Test _parse_transformations method
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = PyTorchTrainingJob(config)
+        transformations = config['dataset']['transformations']
+        transformations = job._parse_transformations(transformations)
+
+        assert len(transformations) == 3
+
+        assert transformations[0][0] == per_image_standardization
+        assert transformations[1][0] == to_tensor
+        assert transformations[2][0] == torch.tensor
+
+        assert transformations[0][1] == {'sample_keys': ['image']}
+        assert transformations[1][1] == {'sample_keys': ['image']}
+        assert (
+            transformations[2][1] ==
+            {'sample_keys': ['label'], 'dtype': torch.int64}
+        )

--- a/tests/integration_tests/training/tf/__init__.py
+++ b/tests/integration_tests/training/tf/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for tensorflow training"""

--- a/tests/integration_tests/training/tf/test_training_job.py
+++ b/tests/integration_tests/training/tf/test_training_job.py
@@ -1,0 +1,121 @@
+"""Integration tests for training.pytorch.training_job"""
+
+import os
+import pytest
+import tempfile
+
+import tensorflow
+from tensorflow import one_hot
+from tensorflow.image import per_image_standardization
+import yaml
+
+from constants import DIRPATH_DLP
+from training.tf.imagenet_trainer import ImageNetTrainer
+from networks.tf.object_classification.alexnet import AlexNet
+from training.tf.training_job import TFTrainingJob
+from utils.test_utils import df_images
+
+
+class TestTFTrainingJob(object):
+    """Tests for TFTrainingJob"""
+
+    @pytest.fixture(scope='class')
+    def fpath_df_images(self, df_images):
+        """Return df_images saved to a temporary file
+
+        :return: filepath to saved df_images
+        :rtype: str
+        """
+
+        df_images = df_images.copy()
+
+        fpath_df_images = tempfile.mkstemp()[1]
+        df_images.to_csv(fpath_df_images, index=False)
+        yield fpath_df_images
+
+    @pytest.fixture(scope='class')
+    def config(self, fpath_df_images):
+        """Return a `config` that specifies the training job
+
+        :return: config file that specifies a TF training job
+        :rtype: dict
+        """
+
+        fpath_config = os.path.join(
+            DIRPATH_DLP, 'training', 'training_configs',
+            'alexnet_imagenet_tf.yml'
+        )
+        with open(fpath_config, 'r') as f:
+            job_config = yaml.load(f)
+        job_config['dataset']['fpath_df_train'] = fpath_df_images
+        job_config['dataset']['train_loading_params']['batch_size'] = 2
+        job_config['dataset']['fpath_df_validation'] = fpath_df_images
+        job_config['dataset']['validation_loading_params']['batch_size'] = 1
+
+        return job_config
+
+    def test_instantiate_dataset(self, config):
+        """Test _instantiate_dataset class
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = TFTrainingJob(config)
+        dataset, n_batches = job._instantiate_dataset(set_name='train')
+        assert n_batches == 1
+        assert isinstance(dataset, tensorflow.data.Dataset)
+
+        dataset, n_batches = job._instantiate_dataset(set_name='validation')
+        assert n_batches == 3
+        assert isinstance(dataset, tensorflow.data.Dataset)
+
+    def test_instantiate_network(self, config):
+        """Test _instantiate_network class
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = TFTrainingJob(config)
+        network = job._instantiate_network()
+        assert isinstance(network, AlexNet)
+        assert network.config['n_channels'] == 3
+        assert network.config['n_classes'] == 1000
+
+    def test_instantiate_trainer(self, config):
+        """Test _instantiate_trainer class
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = TFTrainingJob(config)
+        trainer = job._instantiate_trainer()
+        assert isinstance(trainer, ImageNetTrainer)
+        assert trainer.optimizer == 'adam'
+        assert trainer.loss == 'categorical_crossentropy'
+        assert trainer.batch_size == 128
+        assert trainer.n_epochs == 10
+
+    def test_parse_transformations(self, config):
+        """Test _parse_transformations method
+
+        :param config: config object fixture
+        :type config: dict
+        """
+
+        job = TFTrainingJob(config)
+        transformations = config['dataset']['transformations']
+        transformations = job._parse_transformations(transformations)
+
+        assert len(transformations) == 2
+
+        assert transformations[0][0] == one_hot
+        assert transformations[1][0] == per_image_standardization
+
+        assert (
+            transformations[0][1] ==
+            {'sample_keys': ['label'], 'depth': 1000}
+        )
+        assert transformations[1][1] == {'sample_keys': ['image']}

--- a/tests/unit_tests/datasets/test_imagenet_dataset.py
+++ b/tests/unit_tests/datasets/test_imagenet_dataset.py
@@ -48,7 +48,7 @@ class TestImageNetDataSet(object):
 
         # === test all attributes are set correctly === #
         dataset = ImageNetDataSet(df_images, dataset_config)
-        assert dataset.df_images.equals(df_images)
+        assert dataset.df_obs.equals(df_images)
         assert dataset.config == dataset_config
         assert dataset.required_config_keys == {'height', 'width'}
         mock_validate_config.assert_called_once_with(
@@ -74,7 +74,7 @@ class TestImageNetDataSet(object):
         """
 
         imagenet_dataset = MagicMock()
-        imagenet_dataset.df_images = df_images
+        imagenet_dataset.df_obs = df_images
         imagenet_dataset.__len__ = ImageNetDataSet.__len__
 
         assert len(imagenet_dataset) == 3
@@ -92,7 +92,7 @@ class TestImageNetDataSet(object):
         df_images['label'] = df_images['label'].astype(sample_types['label'])
 
         imagenet_dataset = MagicMock()
-        imagenet_dataset.df_images = df_images
+        imagenet_dataset.df_obs = df_images
         imagenet_dataset.config = dataset_config
         imagenet_dataset.sample_types = sample_types
         imagenet_dataset.__getitem__ = ImageNetDataSet.__getitem__


### PR DESCRIPTION
This PR adds integration tests for the `PyTorchTrainingJob` and `TFTrainingJob` classes; it simply tests the parsing on a real config (one in the repo) without mocking anything. It does not add any integration tests for the `train` method, since that would add a good amount of time to the testing and the important pieces of the `train` method already have integration tests written for them. 