### PR TITLE
Improve testing & functionality of TrainingJob classes

### DIFF
--- a/dl_playground/training/pytorch/training_job.py
+++ b/dl_playground/training/pytorch/training_job.py
@@ -43,11 +43,9 @@ class PyTorchTrainingJob(TrainingJob):
         DataSet = import_object(dataset_importpath)
 
         dataset = DataSet(df_obs=df_obs, **dataset_spec['init_params'])
-        if set_name == 'train':
-            transformations = dataset_spec['transformations']
-            transformations = self._parse_transformations(transformations)
-        else:
-            transformations = []
+        transformations_key = '{}_transformations'.format(set_name)
+        transformations = dataset_spec[transformations_key]
+        transformations = self._parse_transformations(transformations)
 
         dataset = PyTorchDataSetTransformer(dataset, transformations)
         loading_params = dataset_spec['{}_loading_params'.format(set_name)]

--- a/dl_playground/training/tf/training_job.py
+++ b/dl_playground/training/tf/training_job.py
@@ -42,11 +42,9 @@ class TFTrainingJob(TrainingJob):
         DataSet = import_object(dataset_importpath)
 
         dataset = DataSet(df_obs=df_obs, **dataset_spec['init_params'])
-        if set_name == 'train':
-            transformations = dataset_spec['transformations']
-            transformations = self._parse_transformations(transformations)
-        else:
-            transformations = []
+        transformations_key = '{}_transformations'.format(set_name)
+        transformations = dataset_spec[transformations_key]
+        transformations = self._parse_transformations(transformations)
 
         loader = TFDataLoader(dataset, transformations)
         loading_params = dataset_spec['{}_loading_params'.format(set_name)]

--- a/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_pytorch.yml
@@ -6,7 +6,23 @@ dataset:
         config:
             height: 227
             width: 227
-    transformations:
+    train_transformations:
+        - datasets.ops.per_image_standardization:
+            sample_keys:
+                value:
+                    - 'image'
+        - torchvision.transforms.functional.to_tensor:
+            sample_keys:
+                value: 
+                    - 'image'
+        - torch.tensor:
+            sample_keys:
+                value: 
+                    - 'label'
+            dtype:
+                import: true
+                value: 'torch.long'
+    validation_transformations:
         - datasets.ops.per_image_standardization:
             sample_keys:
                 value:

--- a/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
@@ -6,7 +6,18 @@ dataset:
         config:
             height: 227
             width: 227
-    transformations:
+    train_transformations:
+        - tensorflow.one_hot:
+            sample_keys:
+                value:
+                    - 'label'
+            depth:
+                value: 1000
+        - tensorflow.image.per_image_standardization:
+            sample_keys:
+                value:
+                    - 'image'
+    validation_transformations:
         - tensorflow.one_hot:
             sample_keys:
                 value:

--- a/tests/integration_tests/training/pytorch/test_training_job.py
+++ b/tests/integration_tests/training/pytorch/test_training_job.py
@@ -1,8 +1,8 @@
 """Integration tests for training.pytorch.training_job"""
 
 import os
-import pytest
 import tempfile
+import pytest
 
 import torch
 from torch.utils.data import DataLoader
@@ -11,8 +11,8 @@ import yaml
 
 from constants import DIRPATH_DLP
 from datasets.ops import per_image_standardization
-from training.pytorch.imagenet_trainer import ImageNetTrainer
 from networks.pytorch.object_classification.alexnet import AlexNet
+from training.pytorch.imagenet_trainer import ImageNetTrainer
 from training.pytorch.training_job import PyTorchTrainingJob
 from utils.test_utils import df_images
 
@@ -108,18 +108,20 @@ class TestPyTorchTrainingJob(object):
         """
 
         job = PyTorchTrainingJob(config)
-        transformations = config['dataset']['transformations']
-        transformations = job._parse_transformations(transformations)
+        for set_name in ['train', 'validation']:
+            transformations_key = '{}_transformations'.format(set_name)
+            transformations = config['dataset'][transformations_key]
+            transformations = job._parse_transformations(transformations)
 
-        assert len(transformations) == 3
+            assert len(transformations) == 3
 
-        assert transformations[0][0] == per_image_standardization
-        assert transformations[1][0] == to_tensor
-        assert transformations[2][0] == torch.tensor
+            assert transformations[0][0] == per_image_standardization
+            assert transformations[1][0] == to_tensor
+            assert transformations[2][0] == torch.tensor
 
-        assert transformations[0][1] == {'sample_keys': ['image']}
-        assert transformations[1][1] == {'sample_keys': ['image']}
-        assert (
-            transformations[2][1] ==
-            {'sample_keys': ['label'], 'dtype': torch.int64}
-        )
+            assert transformations[0][1] == {'sample_keys': ['image']}
+            assert transformations[1][1] == {'sample_keys': ['image']}
+            assert (
+                transformations[2][1] ==
+                {'sample_keys': ['label'], 'dtype': torch.int64}
+            )

--- a/tests/integration_tests/training/tf/test_training_job.py
+++ b/tests/integration_tests/training/tf/test_training_job.py
@@ -1,8 +1,8 @@
 """Integration tests for training.pytorch.training_job"""
 
 import os
-import pytest
 import tempfile
+import pytest
 
 import tensorflow
 from tensorflow import one_hot
@@ -10,8 +10,8 @@ from tensorflow.image import per_image_standardization
 import yaml
 
 from constants import DIRPATH_DLP
-from training.tf.imagenet_trainer import ImageNetTrainer
 from networks.tf.object_classification.alexnet import AlexNet
+from training.tf.imagenet_trainer import ImageNetTrainer
 from training.tf.training_job import TFTrainingJob
 from utils.test_utils import df_images
 
@@ -106,16 +106,18 @@ class TestTFTrainingJob(object):
         """
 
         job = TFTrainingJob(config)
-        transformations = config['dataset']['transformations']
-        transformations = job._parse_transformations(transformations)
+        for set_name in ['train', 'validation']:
+            transformations_key = '{}_transformations'.format(set_name)
+            transformations = config['dataset'][transformations_key]
+            transformations = job._parse_transformations(transformations)
 
-        assert len(transformations) == 2
+            assert len(transformations) == 2
 
-        assert transformations[0][0] == one_hot
-        assert transformations[1][0] == per_image_standardization
+            assert transformations[0][0] == one_hot
+            assert transformations[1][0] == per_image_standardization
 
-        assert (
-            transformations[0][1] ==
-            {'sample_keys': ['label'], 'depth': 1000}
-        )
-        assert transformations[1][1] == {'sample_keys': ['image']}
+            assert (
+                transformations[0][1] ==
+                {'sample_keys': ['label'], 'depth': 1000}
+            )
+            assert transformations[1][1] == {'sample_keys': ['image']}

--- a/tests/unit_tests/training/pytorch/test_training_job.py
+++ b/tests/unit_tests/training/pytorch/test_training_job.py
@@ -28,7 +28,8 @@ class TestPyTorchTrainingJob(object):
             'fpath_df_validation': 'fpath/df/validation',
             'importpath': 'path/to/import',
             'init_params': {'key1': 'value1', 'key2': 'value2'},
-            'transformations': {'key3': 'value3', 'key4': 'value4'},
+            'train_transformations': {'key3': 'value3', 'key4': 'value4'},
+            'validation_transformations': {'key5': 'value5', 'key6': 'value6'},
             'train_loading_params': {'batch_size': 2},
             'validation_loading_params': {'batch_size': 4}
         }}
@@ -53,6 +54,11 @@ class TestPyTorchTrainingJob(object):
         :param monkeypatch: monkeypatch object
         :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
         """
+
+        training_job._parse_transformations = MagicMock()
+        training_job._parse_transformations.return_value = (
+            'return_from_parse_transformations'
+        )
 
         mock_read_csv = MagicMock()
         mock_read_csv.return_value = 'return_from_read_csv'
@@ -103,8 +109,11 @@ class TestPyTorchTrainingJob(object):
         else:
             assert n_batches == 2
             mock_read_csv.assert_called_once_with('fpath/df/validation')
+            training_job._parse_transformations.assert_called_once_with(
+                {'key5': 'value5', 'key6': 'value6'}
+            )
             mock_transformer.assert_called_once_with(
-                'return_from_dataset_init', []
+                'return_from_dataset_init', 'return_from_parse_transformations'
             )
             mock_loader.assert_called_once_with(
                 mock_transformer_return, batch_size=4
@@ -160,10 +169,6 @@ class TestPyTorchTrainingJob(object):
 
         training_job = MagicMock()
         training_job.config = self._get_mock_config()
-        training_job._parse_transformations = MagicMock()
-        training_job._parse_transformations.return_value = (
-            'return_from_parse_transformations'
-        )
         training_job._instantiate_dataset = (
             PyTorchTrainingJob._instantiate_dataset
         )

--- a/tests/unit_tests/training/test_training_job.py
+++ b/tests/unit_tests/training/test_training_job.py
@@ -161,7 +161,7 @@ class TestTrainingJob(object):
         ]
 
     def test_run(self):
-        """Test train method"""
+        """Test run method"""
 
         training_job = create_autospec(TrainingJob)
         training_job._instantiate_dataset.return_value = ('mock_dataset', 10)

--- a/tests/unit_tests/training/test_training_job.py
+++ b/tests/unit_tests/training/test_training_job.py
@@ -1,6 +1,6 @@
 """Unit tests for training.training_job"""
 
-from unittest.mock import call, MagicMock
+from unittest.mock import call, create_autospec, MagicMock
 import pytest
 
 from training.training_job import TrainingJob
@@ -159,3 +159,24 @@ class TestTrainingJob(object):
             ('import_object_return',
              {'sample_keys': ['image'], 'dtype': 'import_object_return'})
         ]
+
+    def test_run(self):
+        """Test train method"""
+
+        training_job = create_autospec(TrainingJob)
+        training_job._instantiate_dataset.return_value = ('mock_dataset', 10)
+        training_job.run = TrainingJob.run
+
+        training_job.run(self=training_job)
+        training_job._instantiate_network.assert_called_once_with()
+        training_job._instantiate_trainer.assert_called_once_with()
+        training_job._instantiate_dataset.assert_has_calls([
+            call(set_name='train'), call(set_name='validation')
+        ])
+
+        trainer = training_job._instantiate_trainer()
+        trainer.train.assert_called_once_with(
+            network=training_job._instantiate_network(),
+            train_dataset='mock_dataset', n_steps_per_epoch=10,
+            validation_dataset='mock_dataset', n_validation_steps=10
+        )


### PR DESCRIPTION
This PR adds two things: 

1. A unit test for the `TrainingJob.run` method; looks like this was missed when the original test suite was committed. 
2. Differentiating between `train_transformations` (applied to the training set) and `validation_transformations` in the config (and subsequently when instantiating datasets in the subclassed `TrainingJob` classes). Previously, the thought was that (for now) there would be no validation transformations, since data augmentation isn't really applied to the validation set. However, this thought overlooked that there might still be other transformations that should be applied to the validation set, e.g. resizing and normalization. So, there is now a way to specify differing sets of transformations for the training and validation sets. 