### PR TITLE
Add directory path attributes to support saving

### DIFF
--- a/dl_playground/training/pytorch/imagenet_trainer.py
+++ b/dl_playground/training/pytorch/imagenet_trainer.py
@@ -10,7 +10,7 @@ class ImageNetTrainer(object):
 
     required_config_keys = {'batch_size', 'loss', 'n_epochs', 'optimizer'}
 
-    def __init__(self, config):
+    def __init__(self, config, dirpath_save):
         """Init
 
         config must contain the following keys:
@@ -25,6 +25,9 @@ class ImageNetTrainer(object):
 
         :param config: specifies the configuration of the trainer
         :type config: dict
+        :param dirpath_save: directory path to save the model to during
+         training
+        :type dirpath_save: str
         """
 
         validate_config(config, self.required_config_keys)
@@ -34,6 +37,8 @@ class ImageNetTrainer(object):
         self.batch_size = config['batch_size']
         self.n_epochs = config['n_epochs']
         self.device = config.get('device')
+
+        self.dirpath_save = dirpath_save
 
     def train(self, network, train_dataset, n_steps_per_epoch,
               validation_dataset=None, n_validation_steps=None):

--- a/dl_playground/training/tf/imagenet_trainer.py
+++ b/dl_playground/training/tf/imagenet_trainer.py
@@ -10,7 +10,7 @@ class ImageNetTrainer(object):
 
     required_config_keys = {'batch_size', 'loss', 'n_epochs', 'optimizer'}
 
-    def __init__(self, config):
+    def __init__(self, config, dirpath_save):
         """Init
 
         config must contain the following keys:
@@ -21,6 +21,9 @@ class ImageNetTrainer(object):
 
         :param config: specifies the configuration of the trainer
         :type config: dict
+        :param dirpath_save: directory path to save the model to during
+         training
+        :type dirpath_save: str
         """
 
         validate_config(config, self.required_config_keys)
@@ -29,6 +32,8 @@ class ImageNetTrainer(object):
         self.loss = config['loss']
         self.batch_size = config['batch_size']
         self.n_epochs = config['n_epochs']
+
+        self.dirpath_save = dirpath_save
 
     def train(self, network, train_dataset, n_steps_per_epoch,
               validation_dataset=None, n_validation_steps=None):

--- a/tests/integration_tests/training/tf/test_imagenet_trainer.py
+++ b/tests/integration_tests/training/tf/test_imagenet_trainer.py
@@ -1,5 +1,7 @@
 """Integration tests for training.tf.imagenet_trainer"""
 
+import tempfile
+
 import tensorflow as tf
 
 from datasets.imagenet_dataset import ImageNetDataSet
@@ -36,7 +38,10 @@ class TestImageNetTrainer(object):
         ]
 
         alexnet = AlexNet(network_config)
-        imagenet_trainer = ImageNetTrainer(trainer_config)
+        tempdir = tempfile.mkdtemp()
+        imagenet_trainer = ImageNetTrainer(
+            trainer_config, dirpath_save=tempdir
+        )
 
         imagenet_dataset = ImageNetDataSet(df_images, dataset_config)
         tf_data_loader = TFDataLoader(imagenet_dataset)

--- a/tests/unit_tests/training/pytorch/test_imagenet_trainer.py
+++ b/tests/unit_tests/training/pytorch/test_imagenet_trainer.py
@@ -4,7 +4,6 @@ from unittest.mock import patch, MagicMock
 
 from training.pytorch.model import Model
 from training.pytorch.imagenet_trainer import ImageNetTrainer
-from utils.generic_utils import cycle
 
 
 class TestImageNetTrainer(object):
@@ -33,8 +32,10 @@ class TestImageNetTrainer(object):
             'optimizer': 'Adam', 'loss': 'CrossEntropyLoss',
             'batch_size': self.BATCH_SIZE, 'n_epochs': 2, 'device': 'cpu'
         }
-        imagenet_trainer = ImageNetTrainer(trainer_config)
+        dirpath_save = MagicMock()
+        imagenet_trainer = ImageNetTrainer(trainer_config, dirpath_save)
 
+        assert imagenet_trainer.dirpath_save == dirpath_save
         assert imagenet_trainer.optimizer == 'Adam'
         assert imagenet_trainer.loss == 'CrossEntropyLoss'
         assert imagenet_trainer.batch_size == self.BATCH_SIZE

--- a/tests/unit_tests/training/tf/test_imagenet_trainer.py
+++ b/tests/unit_tests/training/tf/test_imagenet_trainer.py
@@ -55,8 +55,10 @@ class TestImageNetTrainer(object):
             'optimizer': 'adam', 'loss': 'categorical_crossentropy',
             'batch_size': self.BATCH_SIZE, 'n_epochs': 2
         }
-        imagenet_trainer = ImageNetTrainer(trainer_config)
+        dirpath_save = MagicMock()
+        imagenet_trainer = ImageNetTrainer(trainer_config, dirpath_save)
 
+        assert imagenet_trainer.dirpath_save == dirpath_save
         assert imagenet_trainer.optimizer == 'adam'
         assert imagenet_trainer.loss == 'categorical_crossentropy'
         assert imagenet_trainer.batch_size == self.BATCH_SIZE


### PR DESCRIPTION
This PR adds the ability to specify a `job_name` and `dirpath_job` for a particular `TrainingJob`, which will then be propagated through to the trainer classes, ultimately saving anything saved during training to the specified directory. 