### PR TITLE
Allow for specifying metrics & callbacks through a YML config

### DIFF
--- a/dl_playground/training/pytorch/imagenet_trainer.py
+++ b/dl_playground/training/pytorch/imagenet_trainer.py
@@ -39,7 +39,8 @@ class ImageNetTrainer(object):
         self.dirpath_save = dirpath_save
 
     def train(self, network, train_dataset, n_steps_per_epoch,
-              validation_dataset=None, n_validation_steps=None):
+              validation_dataset=None, n_validation_steps=None, metrics=None,
+              callbacks=None):
         """Train the network as specified via the __init__ parameters
 
         :param network: network object to use for training
@@ -55,10 +56,17 @@ class ImageNetTrainer(object):
         :param n_validation_steps: number of batches to validate on after each
          epoch
         :type n_validation_steps: int
+        :param metrics: metrics to be evaluated by the model during training
+         and testing
+        :type metrics: list[object]
+        :param callbacks: callbacks to be used during training
+        :type callbacks: list[object]
         """
 
         model = Model(network, self.device)
-        model.compile(optimizer=self.optimizer, loss=self.loss)
+        model.compile(
+            optimizer=self.optimizer, loss=self.loss, metrics=metrics
+        )
 
         if validation_dataset:
             validation_dataset = cycle(validation_dataset)
@@ -68,5 +76,6 @@ class ImageNetTrainer(object):
             n_steps_per_epoch=n_steps_per_epoch,
             n_epochs=self.n_epochs,
             validation_data=validation_dataset,
-            n_validation_steps=n_validation_steps
+            n_validation_steps=n_validation_steps,
+            callbacks=callbacks
         )

--- a/dl_playground/training/pytorch/model.py
+++ b/dl_playground/training/pytorch/model.py
@@ -158,7 +158,8 @@ class Model(object):
         return validation_outputs
 
     def fit_generator(self, generator, n_steps_per_epoch, n_epochs=1,
-                      validation_data=None, n_validation_steps=None):
+                      validation_data=None, n_validation_steps=None,
+                      callbacks=None):
         """Train the network on batches of data generated from `generator`
 
         :param generator: a generator yielding batches indefinitely, where each
@@ -174,11 +175,15 @@ class Model(object):
         :type validation_data: generator
         :param n_validation_steps: number of batches to evaluate on from
          `validation_data`
+        :param callbacks: callbacks to be used during training
+        :type callbacks: list[object]
         :raises RuntimeError: if only one of `validation_data` and
          `n_validation_steps` are passed in
         """
 
         default_callbacks = self._default_callbacks()
+        if callbacks:
+            default_callbacks.extend(callbacks)
         callbacks = CallbackList(default_callbacks)
 
         self._assert_compiled()

--- a/dl_playground/training/tf/imagenet_trainer.py
+++ b/dl_playground/training/tf/imagenet_trainer.py
@@ -36,7 +36,8 @@ class ImageNetTrainer(object):
         self.dirpath_save = dirpath_save
 
     def train(self, network, train_dataset, n_steps_per_epoch,
-              validation_dataset=None, n_validation_steps=None):
+              validation_dataset=None, n_validation_steps=None, metrics=None,
+              callbacks=None):
         """Train the network as specified via the __init__ parameters
 
         :param network: network object to use for training
@@ -52,11 +53,18 @@ class ImageNetTrainer(object):
         :param n_validation_steps: number of batches to validate on after each
          epoch
         :type n_validation_steps: int
+        :param metrics: metrics to be evaluated by the model during training
+         and testing
+        :type metrics: list[object]
+        :param callbacks: callbacks to be used during training
+        :type callbacks: list[object]
         """
 
         inputs, outputs = network.forward()
         model = Model(inputs=inputs, outputs=outputs)
-        model.compile(optimizer=self.optimizer, loss=self.loss)
+        model.compile(
+            optimizer=self.optimizer, loss=self.loss, metrics=metrics
+        )
 
         model.fit(
             x=train_dataset,
@@ -64,5 +72,6 @@ class ImageNetTrainer(object):
             epochs=self.n_epochs,
             verbose=True,
             validation_data=validation_dataset,
-            validation_steps=n_validation_steps
+            validation_steps=n_validation_steps,
+            callbacks=callbacks
         )

--- a/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
@@ -54,3 +54,7 @@ trainer:
             loss: 'categorical_crossentropy'
             batch_size: 128
             n_epochs: 10
+    callbacks:
+        - tensorflow.keras.callbacks.CSVLogger
+    metrics:
+        - tensorflow.keras.metrics.categorical_accuracy

--- a/tests/unit_tests/training/pytorch/test_imagenet_trainer.py
+++ b/tests/unit_tests/training/pytorch/test_imagenet_trainer.py
@@ -77,7 +77,8 @@ class TestImageNetTrainer(object):
             assert fit_fn.call_count == 1
             fit_fn.assert_called_with(
                 generator=mock_cycle_return, n_steps_per_epoch=1,
-                n_epochs=2, validation_data=None, n_validation_steps=None
+                n_epochs=2, validation_data=None, n_validation_steps=None,
+                callbacks=None
             )
             assert mock_compile.call_count == 1
 
@@ -95,6 +96,6 @@ class TestImageNetTrainer(object):
             fit_fn.assert_called_with(
                 generator=mock_cycle_return, n_steps_per_epoch=1,
                 n_epochs=2, validation_data=mock_cycle_return,
-                n_validation_steps=3
+                n_validation_steps=3, callbacks=None
             )
             assert mock_compile.call_count == 1

--- a/tests/unit_tests/training/pytorch/test_model.py
+++ b/tests/unit_tests/training/pytorch/test_model.py
@@ -194,7 +194,6 @@ class TestModel(object):
         model.evaluate_generator = MagicMock()
         model.evaluate_generator.return_value = (2, 3)
         model._default_callbacks = MagicMock()
-        model._default_callbacks.return_value = [1, 2, 3]
         model.metric_names = ['mock_metric']
 
         generator = MagicMock()
@@ -214,6 +213,7 @@ class TestModel(object):
         ]
 
         for test_case in test_cases:
+            model._default_callbacks.return_value = [1, 2, 3]
             early_stopping = test_case.get('early_stopping', False)
 
             n_steps_per_epoch = test_case['n_steps_per_epoch']
@@ -234,7 +234,8 @@ class TestModel(object):
                 self=model, generator=generator,
                 n_steps_per_epoch=n_steps_per_epoch, n_epochs=n_epochs,
                 validation_data=validation_data,
-                n_validation_steps=n_validation_steps
+                n_validation_steps=n_validation_steps,
+                callbacks=[4, 5]
             )
             if early_stopping:
                 model.stop_training = True
@@ -257,7 +258,7 @@ class TestModel(object):
             model.train_on_batch.assert_called_with(inputs, targets)
             assert generator.__next__.call_count == n_batches
 
-            mock_callback_list.assert_called_with([1, 2, 3])
+            mock_callback_list.assert_called_with([1, 2, 3, 4, 5])
             mock_callbacks.set_params.assert_called_with(
                 {'epochs': n_epochs,
                  'metrics':

--- a/tests/unit_tests/training/tf/test_imagenet_trainer.py
+++ b/tests/unit_tests/training/tf/test_imagenet_trainer.py
@@ -86,7 +86,7 @@ class TestImageNetTrainer(object):
             fit_fn.assert_called_with(
                 x=imagenet_dataset, steps_per_epoch=1,
                 epochs=2, verbose=True, validation_data=None,
-                validation_steps=None
+                validation_steps=None, callbacks=None
             )
 
         with patch.object(Model, 'fit') as fit_fn:
@@ -99,5 +99,5 @@ class TestImageNetTrainer(object):
             fit_fn.assert_called_with(
                 x=imagenet_dataset, steps_per_epoch=45,
                 epochs=2, verbose=True, validation_data=imagenet_dataset,
-                validation_steps=2
+                validation_steps=2, callbacks=None
             )


### PR DESCRIPTION
This PR adds the ability to specify callbacks and / or metrics via the YML config. 