### PR TITLE
Add in ToyImageDataSet

### DIFF
--- a/dl_playground/datasets/toy_image_dataset.py
+++ b/dl_playground/datasets/toy_image_dataset.py
@@ -1,0 +1,394 @@
+"""Toy dataset for verifying / validating new network implementations"""
+
+from itertools import product
+import operator
+
+import numpy as np
+import skimage.draw
+from torch.utils.data import Dataset
+
+from utils.generic_utils import validate_config
+
+OBJECT_COLORS = {
+    'red': (1, 0, 0), 'orange': (1, 0.6471, 0), 'yellow': (1, 1, 0),
+    'green': (0, 0.5, 0), 'blue': (0, 0, 1), 'indigo': (0.2941, 0, 0.5098),
+    'violet': (0.9333, 0.5098, 0.9333), 'white': (1, 1, 1), 'black': (0, 0, 0)
+}
+OBJECT_SHAPES = ['ellipse', 'line', 'rectangle', 'triangle']
+OBJECT_SIZES = ['small', 'medium', 'large']
+
+MAX_FRACTION_OFFSETS_DICT = {
+    'small': 0.85, 'medium': 0.70, 'large': 0.55
+}
+SIZE_BOUNDS_DICT = {
+    'small': (0.05, 0.15), 'medium': (0.20, 0.40), 'large': (0.50, 0.70)
+}
+
+
+def generate_ellipse_coordinates(image_shape, centerpoint, size_bin):
+    """Generate coordinates for a randomly placed ellipse in an image
+
+    This generates image coordinates to place a randomly generated ellipse
+    within an image. The size of the ellipse is bounded by the `size_bin`
+    argument, where 'small' bounds it to > 5% and <=15% of the `image_shape`,
+    'medium' bounds it to >20% and <= 40% of the `image_shape`, and 'large'
+    bounds it to >50% and <=70%, but randomly chosen within those bounds.
+
+    :param image_shape: (height, width) of the image that the ellipse will be
+     placed into
+    :type image_shape: tuple(int)
+    :param centerpoint: (y, x) coordinates denoting the center of the ellipse
+    :type centerpoint: tuple(int)
+    :param size_bin: size bin that the ellipse should fall in, one of
+     `OBJECT_SIZES`
+    :type size_bin: str
+    :return: coordinates into a numpy.ndarray of `image_shape` that represent
+     the randomly generated ellipse
+    :rtype: tuple(numpy.ndarray)
+    """
+
+    size_bounds = SIZE_BOUNDS_DICT[size_bin]
+
+    # divide by 2 because these will be used to calculate the radius, and the
+    # `size_bounds` themselves are relative to the entire object (and the
+    # radius only represents half of an ellipse's bounds)
+    y_radius_min = image_shape[0] * size_bounds[0] // 2.
+    y_radius_max = image_shape[0] * size_bounds[1] // 2.
+    x_radius_min = image_shape[1] * size_bounds[0] // 2.
+    x_radius_max = image_shape[1] * size_bounds[1] // 2.
+
+    y_radius = np.random.randint(y_radius_min, y_radius_max)
+    x_radius = np.random.randint(x_radius_min, x_radius_max)
+    y_radius = max(y_radius, 2)
+    x_radius = max(x_radius, 2)
+
+    ellipse_coordinates = skimage.draw.ellipse(
+        r=centerpoint[0], c=centerpoint[1],
+        r_radius=y_radius, c_radius=x_radius,
+        shape=image_shape
+    )
+    return ellipse_coordinates
+
+
+def generate_line_coordinates(image_shape, centerpoint, size_bin):
+    """Generate coordinates for a randomly placed line in an image
+
+    This generates image coordinates to place a randomly generated line
+    within an image. The size of the line is bounded by the `size_bin`
+    argument, where 'small' bounds it to > 5% and <=15% of the `image_shape`,
+    'medium' bounds it to >20% and <= 40% of the `image_shape`, and 'large'
+    bounds it to >50% and <=70%, but randomly chosen within those bounds.
+
+    :param image_shape: (height, width) of the image that the line will be
+     placed into
+    :type image_shape: tuple(int)
+    :param centerpoint: (y, x) coordinates denoting the center of the line
+    :type centerpoint: tuple(int)
+    :param size_bin: size bin that the line should fall in, one of
+     `OBJECT_SIZES`
+    :type size_bin: str
+    :return: coordinates into a numpy.ndarray of `image_shape` that represent
+     the randomly generated line
+    :rtype: tuple(numpy.ndarray)
+    """
+
+    size_bounds = SIZE_BOUNDS_DICT[size_bin]
+
+    height_min = int(image_shape[0] * size_bounds[0])
+    height_max = int(image_shape[0] * size_bounds[1])
+    width_min = int(image_shape[1] * size_bounds[0])
+    width_max = int(image_shape[1] * size_bounds[1])
+
+    height = np.random.randint(height_min, height_max)
+    width = np.random.randint(width_min, width_max)
+
+    y_op_choices = np.random.choice(
+        [operator.sub, operator.add], size=2, replace=False
+    )
+    x_op_choices = np.random.choice(
+        [operator.sub, operator.add], size=2, replace=False
+    )
+
+    y_vertices = (
+        int(y_op_choices[0](centerpoint[0], height // 2.)),
+        int(y_op_choices[1](centerpoint[0], height // 2.))
+    )
+    x_vertices = (
+        int(x_op_choices[0](centerpoint[0], width // 2.)),
+        int(x_op_choices[1](centerpoint[0], width // 2.))
+    )
+    line_coordinates = skimage.draw.line(
+        y_vertices[0], x_vertices[0],
+        y_vertices[1], x_vertices[1]
+    )
+
+    return line_coordinates
+
+
+def generate_rectangle_coordinates(image_shape, centerpoint, size_bin):
+    """Generate coordinates for a randomly placed rectangle in an image
+
+    This generates image coordinates to place a randomly generated rectangle
+    within an image. The size of the rectangle is bounded by the `size_bin`
+    argument, where 'small' bounds it to > 5% and <=15% of the `image_shape`,
+    'medium' bounds it to >20% and <= 40% of the `image_shape`, and 'large'
+    bounds it to >50% and <=70%, but randomly chosen within those bounds.
+
+    :param image_shape: (height, width) of the image that the rectangle will be
+     placed into
+    :type image_shape: tuple(int)
+    :param centerpoint: (y, x) coordinates denoting the center of the rectangle
+    :type centerpoint: tuple(int)
+    :param size_bin: size bin that the rectangle should fall in, one of
+     `OBJECT_SIZES`
+    :type size_bin: str
+    :return: coordinates into a numpy.ndarray of `image_shape` that represent
+     the randomly generated rectangle
+    :rtype: tuple(numpy.ndarray)
+    """
+
+    size_bounds = SIZE_BOUNDS_DICT[size_bin]
+
+    height_min = int(image_shape[0] * size_bounds[0])
+    height_max = int(image_shape[0] * size_bounds[1])
+    width_min = int(image_shape[1] * size_bounds[0])
+    width_max = int(image_shape[1] * size_bounds[1])
+
+    height = np.random.randint(height_min, height_max)
+    width = np.random.randint(width_min, width_max)
+
+    y_vertices = (
+        centerpoint[0] - height // 2,
+        centerpoint[0] - height // 2,
+        centerpoint[0] + height // 2,
+        centerpoint[0] + height // 2
+    )
+    x_vertices = (
+        centerpoint[1] - width // 2,
+        centerpoint[1] + width // 2,
+        centerpoint[1] + width // 2,
+        centerpoint[1] - width // 2
+    )
+    rectangle_coordinates = skimage.draw.polygon(
+        y_vertices, x_vertices, shape=image_shape
+    )
+
+    return rectangle_coordinates
+
+
+def generate_triangle_coordinates(image_shape, centerpoint, size_bin):
+    """Generate coordinates for a randomly placed triangle in an image
+
+    This generates image coordinates to place a randomly generated triangle
+    within an image. The size of the ellipse is bounded by the `size_bin`
+    argument, where 'small' bounds it to > 5% and <=15% of the `image_shape`,
+    'medium' bounds it to >20% and <= 40% of the `image_shape`, and 'large'
+    bounds it to >50% and <=70%, but randomly chosen within those bounds.
+
+    :param image_shape: (height, width) of the image that the triangle will be
+     placed into
+    :type image_shape: tuple(int)
+    :param centerpoint: (y, x) coordinates denoting the center of the triangle
+    :type centerpoint: tuple(int)
+    :param size_bin: size bin that the ellipse should fall in, one of
+     `OBJECT_SIZES`
+    :type size_bin: str
+    :return: coordinates into a numpy.ndarray of `image_shape` that represent
+     the randomly generated triangle
+    :rtype: tuple(numpy.ndarray)
+    """
+
+    size_bounds = SIZE_BOUNDS_DICT[size_bin]
+
+    # divide by 2 because these will be used to calculate the radius of the
+    # circle surrounding the triangle, and the `size_bounds` themselves are
+    # relative to the entire object (and the radius only represents half of an
+    # circle's bounds)
+    y_min = image_shape[0] * size_bounds[0] // 2.
+    y_max = image_shape[0] * size_bounds[1] // 2.
+    x_min = image_shape[1] * size_bounds[0] // 2.
+    x_max = image_shape[1] * size_bounds[1] // 2.
+
+    y_vertex1 = centerpoint[0] + np.random.randint(y_min, y_max)
+    x_vertex1 = centerpoint[1] + np.random.randint(x_min, x_max)
+
+    y_vertex2 = centerpoint[0] - np.random.randint(y_min, y_max)
+    x_vertex2 = centerpoint[1] - np.random.randint(x_min, x_max)
+
+    y_vertex3 = centerpoint[0] - np.random.randint(y_min, y_max)
+    x_vertex3 = centerpoint[1] + np.random.randint(x_min, x_max)
+
+    triangle_coordinates = skimage.draw.polygon(
+        [y_vertex1, y_vertex2, y_vertex3], [x_vertex1, x_vertex2, x_vertex3],
+        shape=image_shape
+    )
+    return triangle_coordinates
+
+
+class ToyImageDataSet(Dataset):
+    """ToyImageDataSet
+
+    This dataset is intended to be used as a means to verify new network
+    implementations to ensure that they are able to generalize. It produces
+    input / target pairs for several tasks that should be easy for a network to
+    learn. Since each input / target pair is randomly generated, each pair is
+    effectively a "new" example for the network, and thus the input / target
+    pairs from a single ToyImageDataSet object can be treated as coming from
+    the training, validation, or test sets.
+
+    Currently, the following types of tasks are supported:
+    - Classification (for arbitrarily many classes up to 108), where the
+      network needs to classify the target type, which is defined by the color
+      (see OBJECT_COLORS), shape (see OBJECT_SHAPES), and size (see
+      OBJECT_SIZES) of the object in the input image
+    """
+
+    required_config_keys = {'height', 'width', 'n_classes'}
+
+    def __init__(self, config, size=None):
+        """Init
+
+        `config` must contain the following keys:
+        - int height: height of the images to create
+        - int width: width of the images to create
+        - int n_classes: number of classes of target to use when creating the
+          data
+
+        It can additionally contain the following keys:
+        - list[str] object_colors: colors to use for the object in each
+          image; options include those in OBJECT_COLORS; defaults to
+          OBJECT_COLORS
+        - list[str] object_shapes: shapes to use for the object in each
+          image; options include those in OBJECT_SHAPES; defaults to
+          OBJECT_SHAPES
+        - list[str] object_sizes: sizes to use for the object in each image;
+          options include those in OBJECT_SIZES; defaults to OBJECT_SIZES
+
+        :param config: specifies the configuration of the image, label pairs to
+         generate as part of the dataset
+        :param config: dict
+        :param size: number of elements to return from the dataset before it is
+         exhausted (i.e. before it is iterated over one time to completion),
+         defaults to the number of unique combinations of object_colors,
+         object_shapes, and object_sizes specified iin the config
+        :type size: int
+        """
+
+        validate_config(config, self.required_config_keys)
+
+        self.height = config['height']
+        self.width = config['width']
+        self.n_classes = config['n_classes']
+
+        object_colors = config.get('object_colors', list(OBJECT_COLORS.keys()))
+        # sort so that the order is always the same
+        object_colors = sorted(object_colors)
+        object_shapes = config.get('object_shapes', OBJECT_SHAPES)
+        object_sizes = config.get('object_sizes', OBJECT_SIZES)
+
+        msg = '{} contains an invalid option. Valid options are: {}'
+        if set(object_colors).difference(OBJECT_COLORS):
+            raise ValueError(msg.format('object_colors', OBJECT_COLORS))
+        if set(object_shapes).difference(OBJECT_SHAPES):
+            raise ValueError(msg.format('object_shapes', OBJECT_SHAPES))
+        if set(object_sizes).difference(object_sizes):
+            raise ValueError(msg.format('object_sizes', OBJECT_SIZES))
+
+        self.object_colors = object_colors
+        self.object_shapes = object_shapes
+        self.object_sizes = object_sizes
+        object_spec_options = list(product(
+            object_colors, object_shapes, object_sizes
+        ))[:self.n_classes]
+        self.object_spec_options = {
+            idx_spec: object_spec
+            for idx_spec, object_spec in enumerate(object_spec_options)
+        }
+
+        if size is None:
+            size = len(self.object_spec_options)
+        self.size = size
+
+    def __getitem__(self, _):
+        """Return an randomly generated image, label pair
+
+        :param _: unused
+        :type _: int
+        :return: dict with keys:
+        - numpy.ndarray image: pixel data that contains a fuzzy background and
+          a generated object in the foreground
+        - int label: class label assigned to the returned image, corresponding
+          to the color, shape, and size of the object in the foreground
+        :rtype: dict
+        """
+
+        random_array = np.random.random((self.height, self.width))
+        random_array = np.expand_dims(random_array, axis=-1)
+        zeros = np.zeros_like(random_array)
+        image = np.concatenate([random_array, zeros, zeros], axis=-1)
+
+        idx_object_spec = np.random.choice(len(self.object_spec_options))
+        object_color, object_shape, object_size = (
+            self.object_spec_options[idx_object_spec]
+        )
+        object_slices = self._get_object_coordinates(
+            object_shape, object_size
+        )
+        object_values = OBJECT_COLORS[object_color]
+        for idx_channel, channel_value in enumerate(object_values):
+            image[object_slices[0], object_slices[1], idx_channel] = (
+                channel_value
+            )
+
+        return (image, idx_object_spec)
+
+    def __len__(self):
+        """Return the size of the dataset
+
+        :return: size of the dataset
+        :rtype: int
+        """
+
+        return self.size
+
+    def _get_object_coordinates(self, object_shape, object_size):
+        """Return coordinates to add an object to an image
+
+        :param object_shape: shape of the object, one of self.object_shapes
+        :type object_shape: str
+        :param object_size: size of the object, one of self.object_sizes
+        :type object_size: str
+        :return: coordinates of the pixels that comprise an object to add to an
+         image
+        :rtype: tuple(numpy.ndarray)
+        """
+
+        max_fraction_offset = MAX_FRACTION_OFFSETS_DICT[object_size]
+        image_shape = (self.height, self.width)
+        max_y_offset = int(image_shape[0] / 2. * max_fraction_offset)
+        max_x_offset = int(image_shape[1] / 2. * max_fraction_offset)
+        center_offset_y = np.random.randint(-max_y_offset, max_y_offset)
+        center_offset_x = np.random.randint(-max_x_offset, max_x_offset)
+        centerpoint = (
+            image_shape[0] // 2. + center_offset_y,
+            image_shape[1] // 2. + center_offset_x
+        )
+
+        if object_shape == 'ellipse':
+            coordinates_fn = generate_ellipse_coordinates
+        elif object_shape == 'rectangle':
+            coordinates_fn = generate_rectangle_coordinates
+        elif object_shape == 'line':
+            coordinates_fn = generate_line_coordinates
+        elif object_shape == 'triangle':
+            coordinates_fn = generate_triangle_coordinates
+
+        object_coordinates = coordinates_fn(
+            image_shape=(self.height, self.width), centerpoint=centerpoint,
+            size_bin=object_size
+        )
+        object_coordinates = (
+            np.minimum(object_coordinates[0], image_shape[0] - 1),
+            np.minimum(object_coordinates[1], image_shape[1] - 1)
+        )
+        return object_coordinates

--- a/tests/unit_tests/datasets/test_toy_image_dataset.py
+++ b/tests/unit_tests/datasets/test_toy_image_dataset.py
@@ -1,0 +1,298 @@
+"""Unit tests for dataset.toy_image_dataset"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from scipy.ndimage.measurements import center_of_mass
+
+from datasets.toy_image_dataset import (
+    generate_ellipse_coordinates, generate_line_coordinates,
+    generate_rectangle_coordinates, generate_triangle_coordinates,
+    ToyImageDataSet
+)
+
+TEST_CASES = [
+    {'image_shape': (64, 64), 'centerpoint': (32, 32),
+     'size_bin': 'small'},
+    {'image_shape': (96, 96), 'centerpoint': (48, 48),
+     'size_bin': 'medium'},
+    {'image_shape': (128, 128), 'centerpoint': (64, 64),
+     'size_bin': 'large'},
+]
+
+
+def check_centerpoint(coordinates, image_shape, expected_centerpoint, atol=1):
+    """Assert that the centerpoint of coordinates is as expected
+
+    :param coordinates: coordinates to check
+    :type coordinates: tuple(numpy.ndarray)
+    :param image_shape: holds the image shape that the coordinates were
+     generated for
+    :type image_shape: tuple(int)
+    :param expected_centerpoint: holds the expected centerpoint
+    :type expected_centerpoint: tuple(float)
+    :param atol: tolerance to allow when checking the centerpoint
+    :type atol: int
+    """
+
+    image = np.zeros(image_shape)
+    image[coordinates] = 1
+    centerpoint = center_of_mass(image)
+    assert np.allclose(centerpoint, expected_centerpoint, atol=atol)
+
+
+def check_size(coordinates, size_bin, image_shape):
+    """Assert that coordinates take up the expected fraction of `image_shape`
+
+    :param coordinates: coordinates to check
+    :type coordinates: tuple(numpy.ndarray)
+    :param size_bin: denotes the size of the shape that the coordinates
+     represent, one of 'small', 'medium', or 'large'
+    :type size_bin: str
+    :param image_shape: holds the image shape that the coordinates were
+     generated for
+    :type image_shape: tuple(int)
+    """
+
+    size_y = (
+        float((max(coordinates[0]) - min(coordinates[0]))) / image_shape[0]
+    )
+    size_x = (
+        float((max(coordinates[1]) - min(coordinates[1]))) / image_shape[1]
+    )
+
+    if size_bin == 'small':
+        min_size = 0.015
+        max_size = 0.15
+    elif size_bin == 'medium':
+        min_size = 0.10
+        max_size = 0.40
+    elif size_bin == 'large':
+        min_size = 0.25
+        max_size = 0.70
+
+    assert min_size <= size_y <= max_size
+    assert min_size <= size_x <= max_size
+
+
+def test_generate_ellipse_coordinates():
+    """Test generate_ellipse_coordinates method
+
+    This acts somewhat like a smoke test, and tests a couple of things:
+    - The returned ellipse takes up roughly the correct portion of the overall
+      image
+    - The centerpoint of the returned ellipse is in the right place
+    """
+
+    for test_case in TEST_CASES:
+        ellipse_coordinates = generate_ellipse_coordinates(**test_case)
+
+        check_size(
+            ellipse_coordinates, test_case['size_bin'],
+            test_case['image_shape']
+        )
+        check_centerpoint(
+            ellipse_coordinates, test_case['image_shape'],
+            test_case['centerpoint']
+        )
+
+
+def test_generate_line_coordinates():
+    """Test generate_ellipse_coordinates method
+
+    This acts somewhat like a smoke test, and tests a couple of things:
+    - The returned line is roughly the expected length
+    - The centerpoint of the returned line is in the right place
+    """
+
+    for test_case in TEST_CASES:
+        line_coordinates = generate_line_coordinates(**test_case)
+
+        check_size(
+            line_coordinates, test_case['size_bin'],
+            test_case['image_shape']
+        )
+        check_centerpoint(
+            line_coordinates, test_case['image_shape'],
+            test_case['centerpoint']
+        )
+
+
+def test_generate_rectangle_coordinates():
+    """Test generate_rectangle_coordinates method
+
+    This acts somewhat like a smoke test, and tests a couple of things:
+    - The returned rectangle takes up roughly the correct portion of the
+      overall image
+    - The centerpoint of the returned rectangle is in the right place
+    """
+
+    for test_case in TEST_CASES:
+        rectangle_coordinates = generate_rectangle_coordinates(**test_case)
+
+        check_size(
+            rectangle_coordinates, test_case['size_bin'],
+            test_case['image_shape']
+        )
+        check_centerpoint(
+            rectangle_coordinates, test_case['image_shape'],
+            test_case['centerpoint']
+        )
+
+
+def test_generate_triangle_coordinates():
+    """Test generate_triangle_coordinates method
+
+    This acts somewhat like a smoke test, and tests a couple of things:
+    - The returned triangle takes up roughly the correct portion of the
+      overall image
+    - The centerpoint of the returned triangle is in the right place
+    """
+
+    for test_case in TEST_CASES:
+        triangle_coordinates = generate_triangle_coordinates(**test_case)
+
+        check_size(
+            triangle_coordinates, test_case['size_bin'],
+            test_case['image_shape']
+        )
+        check_centerpoint(
+            triangle_coordinates, test_case['image_shape'],
+            test_case['centerpoint'], atol=15
+        )
+
+
+class TestToyImageDataSet(object):
+    """Tests for ToyImageDataSet"""
+
+    @pytest.fixture(scope='class')
+    def dataset_config(self):
+        """dataset_config object fixture
+
+        :return: dataset_config to be used to instantiate a ToyImageDataSet
+        :rtype: dict
+        """
+
+        return {
+            'height': 64, 'width': 64, 'n_classes': 8,
+            'object_colors': ['red', 'yellow', 'orange'],
+            'object_shapes': ['ellipse'],
+        }
+
+    def test_init(self, dataset_config, monkeypatch):
+        """Test __init__ method
+
+        This tests that all attributes are set correctly in the __init__.
+
+        :param dataset_config: dataset_config object fixture
+        :type: dict
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_validate_config = MagicMock()
+        monkeypatch.setattr(
+            'datasets.toy_image_dataset.validate_config', mock_validate_config
+        )
+
+        dataset = ToyImageDataSet(dataset_config)
+        assert dataset.height == 64
+        assert dataset.width == 64
+        assert dataset.n_classes == 8
+        assert dataset.object_colors == ['orange', 'red', 'yellow']
+        assert dataset.object_shapes == ['ellipse']
+        assert dataset.object_sizes == ['small', 'medium', 'large']
+        assert len(dataset.object_spec_options) == 8
+        assert dataset.size == 8
+        assert len(dataset) == 8
+
+    def test_init__errors(self, dataset_config, monkeypatch):
+        """Test __init__ method
+
+        This tests that if a n invalid object shape, size, or color is
+        specified, a ValueError is raised.
+
+        :param dataset_config: dataset_config object fixture
+        :type: dict
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_validate_config = MagicMock()
+        monkeypatch.setattr(
+            'datasets.toy_image_dataset.validate_config', mock_validate_config
+        )
+
+        with pytest.raises(ValueError):
+            dataset_config = dataset_config.copy()
+            dataset_config['object_shapes'] = ['taco']
+            ToyImageDataSet(dataset_config)
+
+        with pytest.raises(ValueError):
+            dataset_config = dataset_config.copy()
+            dataset_config['object_sizes'] = ['gigantic']
+            ToyImageDataSet(dataset_config)
+
+        with pytest.raises(ValueError):
+            dataset_config = dataset_config.copy()
+            dataset_config['object_colors'] = ['sky-blue']
+            ToyImageDataSet(dataset_config)
+
+    def test_getitem(self):
+        """Test __getitem__ method"""
+
+        mock_dataset = MagicMock()
+        mock_dataset.height = 64
+        mock_dataset.width = 64
+        mock_get_object_coordinates = MagicMock()
+        mock_get_object_coordinates.return_value = ([0], [1])
+
+        mock_dataset._get_object_coordinates = mock_get_object_coordinates
+        mock_dataset.object_spec_options = {
+            0: ('red', 'triangle', 'small')
+        }
+
+        mock_dataset.__getitem__ = ToyImageDataSet.__getitem__
+        image, label = mock_dataset[2]
+
+        assert image.shape == (64, 64, 3)
+        assert image[0, 1, 0] == 1
+        assert image[0, 1, 1] == 0
+        assert image[0, 1, 2] == 0
+        assert label == 0
+
+    def test_get_object_coordinates(self, monkeypatch):
+        """Test get_object_coordinates method
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_dataset = MagicMock()
+        mock_dataset.height = 64
+        mock_dataset.width = 64
+
+        mock_generate_ellipse_coordinates = MagicMock()
+        mock_generate_ellipse_coordinates.return_value = (
+            [4, 5, 7, 65, 66, 12], [7, 8, 9, 12, 68, 7]
+        )
+        monkeypatch.setattr(
+            'datasets.toy_image_dataset.generate_ellipse_coordinates',
+            mock_generate_ellipse_coordinates
+        )
+
+        mock_dataset._get_object_coordinates = (
+            ToyImageDataSet._get_object_coordinates
+        )
+        object_coordinates = mock_dataset._get_object_coordinates(
+            self=mock_dataset, object_shape='ellipse', object_size='small'
+        )
+
+        assert np.array_equal(
+            object_coordinates[0], [4, 5, 7, 63, 63, 12]
+        )
+        assert np.array_equal(
+            object_coordinates[1], [7, 8, 9, 12, 63, 7]
+        )
+        assert mock_generate_ellipse_coordinates.call_count == 1


### PR DESCRIPTION
This PR adds in a `ToyImageDataSet` class that can be used to test network designs on an easy problem to make sure they work as expected. The dataset spits out images with a simple geometric shape in the foreground and a label that corresponds to the type, color, and size of that shape. In the future it could be updated to use for localization / detection tasks and / or semantic segmentation tasks as well. 