### PR TITLE
Add PyTorch ResNet implementation

### DIFF
--- a/dl_playground/networks/pytorch/object_classification/alexnet.py
+++ b/dl_playground/networks/pytorch/object_classification/alexnet.py
@@ -35,10 +35,10 @@ class AlexNet(Module):
         self._set_layers()
 
     def _set_layers(self):
-        """Set the networks layers used in the forward pass
+        """Set the network's layers used in the forward pass
 
         This sets 5 convolutional layers (self.conv[1-5]) and 3 linear layers
-        (self.linear[1-3]) in place.
+        (self.linear[1-3]) in-place.
         """
 
         n_channels = self.config['n_channels']

--- a/dl_playground/networks/pytorch/object_classification/resnet.py
+++ b/dl_playground/networks/pytorch/object_classification/resnet.py
@@ -1,0 +1,303 @@
+"""ResNet implementation written with PyTorch
+
+Reference paper: https://arxiv.org/abs/1512.03385
+
+Main Reference Implementation:
+    - https://github.com/KaimingHe/deep-residual-networks/blob
+        /master/prototxt/ResNet-50-deploy.prototxt
+
+Other Reference Implementations:
+
+    - https://github.com/taehoonlee/tensornets/blob/master/tensornets
+        /resnets.py
+    - https://github.com/keras-team/keras-applications/blob/master
+        /keras_applications/resnet50.py
+
+This implementation follows the "Main Reference Implementation" as closely as
+possible, since it is the paper author's implementation. The "Other Reference
+Implementations" were used as a reference, and appear to have slight
+differences from the main implementation (although the `tensornets`
+implementation is extremely close).
+"""
+
+import torch
+from torch.nn import (
+    AvgPool2d, BatchNorm2d, Conv2d, Linear, MaxPool2d, Module, ReLU
+)
+
+from utils.generic_utils import validate_config
+
+
+class BottleneckBlock(Module):
+    """Bottleneck Residual Block"""
+
+    def __init__(self, n_in_channels, n_out_channels):
+        """Init
+
+        :param n_in_channels: number of channels in the inputs passed to the
+         `forward` method
+        :type n_in_channels: int
+        :param n_out_channels: number of output channels (convolutional
+         filters) to use in the convolutions applied to the inputs passed to
+         the `forward` method
+        :type n_out_channels: int
+        """
+
+        super().__init__()
+
+        self.conv1 = Conv2d(
+            in_channels=n_in_channels, out_channels=n_out_channels,
+            kernel_size=(1, 1), stride=(1, 1), bias=False
+        )
+        self.bn1 = BatchNorm2d(num_features=n_out_channels)
+
+        self.conv2 = Conv2d(
+            in_channels=n_out_channels, out_channels=n_out_channels,
+            kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False
+        )
+        self.bn2 = BatchNorm2d(num_features=n_out_channels)
+
+        self.conv3 = Conv2d(
+            in_channels=n_out_channels, out_channels=(n_out_channels * 4),
+            kernel_size=(1, 1), bias=False
+        )
+        self.bn3 = BatchNorm2d(num_features=(n_out_channels * 4))
+
+        self.relu = ReLU()
+
+    def forward(self, inputs):
+        """Return the output of a forward pass of a BottleneckBlock
+
+        :param inputs: batch of input images, of shape
+         (batch_size, height, width, n_in_channels)
+        :type inputs: torch.Tensor
+        :return: outputs of a BottleneckBlock, of shape
+         (batch_size, height, width, n_out_channels * 4)
+        :rtype: torch.Tensor
+        """
+
+        layer = self.conv1(inputs)
+        layer = self.bn1(layer)
+        layer = self.relu(layer)
+
+        layer = self.conv2(layer)
+        layer = self.bn2(layer)
+        layer = self.relu(layer)
+
+        layer = self.conv3(layer)
+        layer = self.bn3(layer)
+
+        layer = torch.add(layer, inputs)
+        layer = self.relu(layer)
+
+        return layer
+
+
+class ProjectionShortcut(Module):
+    """ProjectionShortcut module
+
+    This module is inserted at the beginning of each residual stage, and
+    downsamples the input 2x using a convolution with stride 2 (except for the
+    first residual stage, in which there is no downsampling).
+    """
+
+    def __init__(self, n_in_channels, n_out_channels, stride):
+        """Init
+
+        :param n_in_channels: number of channels in the inputs passed to the
+         `forward` method
+        :type n_in_channels: int
+        :param n_out_channels: number of output channels (convolutional
+         filters) to use in the convolutions applied to the inputs passed to
+         the `forward` method
+        :type n_out_channels: int
+        :param stride: holds the stride to use in the first convolution of the
+         block (i.e. for downsampling)
+        :type stride: tuple(int)
+        """
+
+        super().__init__()
+
+        self.conv1 = Conv2d(
+            in_channels=n_in_channels, out_channels=n_out_channels,
+            kernel_size=(1, 1), stride=stride, bias=False
+        )
+        self.bn1 = BatchNorm2d(num_features=n_out_channels)
+
+        self.conv2 = Conv2d(
+            in_channels=n_out_channels, out_channels=n_out_channels,
+            kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False
+        )
+        self.bn2 = BatchNorm2d(num_features=n_out_channels)
+
+        self.conv3 = Conv2d(
+            in_channels=n_out_channels, out_channels=(n_out_channels * 4),
+            kernel_size=(1, 1), bias=False
+        )
+        self.bn3 = BatchNorm2d(num_features=(n_out_channels * 4))
+
+        self.projection_conv = Conv2d(
+            in_channels=n_in_channels, out_channels=(n_out_channels * 4),
+            kernel_size=(1, 1), stride=stride, bias=False
+        )
+        self.projection_bn = BatchNorm2d(num_features=(n_out_channels * 4))
+
+        self.relu = ReLU()
+
+    def forward(self, inputs):
+        """Return the output of a forward pass of a ProjectionShortcut
+
+        :param inputs: batch of input images, of shape
+         (batch_size, height, width, n_in_channels)
+        :type inputs: torch.Tensor
+        :return: outputs of a BottleneckBlock, of shape
+         (batch_size, height / 2, width / 2, n_out_channels * 4)
+        :rtype: torch.Tensor
+        """
+
+        layer = self.conv1(inputs)
+        layer = self.bn1(layer)
+        layer = self.relu(layer)
+
+        layer = self.conv2(layer)
+        layer = self.bn2(layer)
+        layer = self.relu(layer)
+
+        layer = self.conv3(layer)
+        layer = self.bn3(layer)
+
+        shortcut = self.projection_conv(inputs)
+        shortcut = self.projection_bn(shortcut)
+
+        layer = torch.add(layer, shortcut)
+        layer = self.relu(layer)
+
+        return layer
+
+
+class ResNet(object):
+    """ResNet network"""
+
+    required_config_keys = {
+        'n_channels', 'n_classes', 'n_initial_channels', 'n_blocks_per_stage'
+    }
+
+    def __init__(self, config):
+        """Init
+
+        The `config` must contain the following keys:
+        - int n_channels: number of channels of the input
+        - int n_classes: number of classes in the output layer
+        - int n_initial_channels: number of filters in the initial convolution
+          as well as the first residual block; subsequent residual blocks will
+          have 2x the filters as the previous residual block
+        - list[int] n_blocks_per_stage: iterable holding the number of residual
+          blocks to use per residual stage; the length of n_blocks_per_stage
+          defines the number of residual stages in the network
+
+        :param config: specifies the configuration for the network
+        :type config: dict
+        """
+
+        super().__init__()
+
+        validate_config(config, self.required_config_keys)
+        self.config = config
+
+        self._set_layers()
+
+    def _set_layers(self):
+        """Set the network's layers used in the forward pass
+
+        This sets the following layers in-place:
+        - A general relu used throughout the forward pass
+        - Initial conv, bn, and max pooling layers
+        - Residual stages, each consisting of a ProjectionShortcut module and
+          some number of BottleneckBlock modules. The number of residual stages
+          depends on the length of the `n_blocks_per_stage` iterable in
+          self.config.
+        - Global average pooling layer
+        - Final linear layer
+        """
+
+        n_initial_channels = self.config['n_initial_channels']
+        n_blocks_per_stage = self.config['n_blocks_per_stage']
+
+        self.conv = Conv2d(
+            in_channels=3, out_channels=n_initial_channels, kernel_size=(7, 7),
+            stride=(2, 2), padding=(3, 3)
+        )
+        self.bn = BatchNorm2d(num_features=n_initial_channels)
+        self.relu = ReLU()
+        self.max_pooling = MaxPool2d(kernel_size=(3, 3), stride=(2, 2))
+
+        self.residual_stages = []
+        n_out_channels = n_initial_channels
+        for idx_stage, n_blocks in enumerate(n_blocks_per_stage):
+            stage_blocks = []
+
+            # Each residual block ends with a conv using 4x the number of
+            # n_out_channels, which requires us to adjust n_in_channels to
+            # account for that. The exception is when we first enter the first
+            # residual stage, where the number of channels is simply
+            # n_out_channels.
+            if idx_stage == 0:
+                n_in_channels = n_out_channels
+                stride = (1, 1)
+            else:
+                # Multiply by 2 instead of 4 because at the end of the current
+                # iteration of the for loop the `n_out_channels` will be
+                # multiplied by 2, which accounts for half of the 4x increase
+                # in n_in_channels
+                n_in_channels = n_out_channels * 2
+                stride = (2, 2)
+
+            stage_blocks.append(ProjectionShortcut(
+                n_in_channels, n_out_channels, stride
+            ))
+
+            for _ in range(n_blocks - 1):
+                # n_in_channels passed to BottleneckBlock needs to be 4x
+                # n_out_channels because each ProjectionShortcut ends with a
+                # conv using 4x the number of n_out_channels
+                stage_blocks.append(BottleneckBlock(
+                    n_out_channels * 4, n_out_channels
+                ))
+            self.residual_stages.append(stage_blocks)
+
+            n_out_channels *= 2
+
+        self.average_pooling = AvgPool2d(kernel_size=(7, 7))
+
+        # Divide n_out_channels by 2 to negate the last multiplication in the
+        # for loop that builds the residual stages
+        n_out_channels = n_out_channels // 2 * 4
+        self.linear = Linear(
+            in_features=n_out_channels, out_features=1000
+        )
+
+    def forward(self, inputs):
+        """Return the output of a forward pass of the specified ResNet
+
+        :param inputs: batch of input images, of shape
+         (batch_size, height, width, n_in_channels)
+        :type inputs: torch.Tensor
+        :return: outputs of a forward pass of ResNet, of shape
+         (batch_size, n_classes)
+        :rtype: torch.Tensor
+        """
+
+        layer = self.conv(inputs)
+        layer = self.bn(layer)
+        layer = self.relu(layer)
+        layer = self.max_pooling(layer)
+
+        for residual_stage in self.residual_stages:
+            for residual_block in residual_stage:
+                layer = residual_block(layer)
+
+        layer = self.average_pooling(layer)
+        layer = layer.reshape(layer.size(0), -1)
+        layer = self.linear(layer)
+
+        return layer

--- a/tests/unit_tests/networks/pytorch/object_classification/test_resnet.py
+++ b/tests/unit_tests/networks/pytorch/object_classification/test_resnet.py
@@ -1,0 +1,346 @@
+"""Unit tests for networks.pytorch.object_classification.resnet"""
+
+from unittest.mock import MagicMock
+
+import networks.pytorch.object_classification.resnet as pytorch_resnet
+
+BottleneckBlock = pytorch_resnet.BottleneckBlock
+ProjectionShortcut = pytorch_resnet.ProjectionShortcut
+ResNet = pytorch_resnet.ResNet
+
+
+def check_forward(object_class, attribute_call_counts, monkeypatch):
+    """Assert attribute call counts are met when calling object_class.forward
+
+    This function creates a MagicMock of `object_class`, and additionally
+    creates MagicMock objects for all attributes in `attribute_call_counts` to
+    assign to the MagicMock for `object_class`. It then calls
+    `object_class.forward`, and verifies that each of the attributes is called
+    the expected number of times. It additional checks that torch.add is called
+    once (since this is used to test residual type object classes).
+
+    :param object_class: object class whose forward method will be tested
+    :type object_class: class
+    :param attribute_call_counts: names of attributes and their expected call
+     counts after running `object_class.forward`
+    :type attribute_call_counts: dict
+    :param monkeypatch: monkeypatch object
+    :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+    """
+
+    module = MagicMock()
+    mock_attributes = {}
+    for attr_name in attribute_call_counts:
+        mock_attribute = MagicMock()
+        setattr(module, attr_name, mock_attribute)
+        mock_attributes[attr_name] = mock_attribute
+
+    mock_add = MagicMock()
+    monkeypatch.setattr('torch.add', mock_add)
+
+    module.forward = object_class.forward
+    module.forward(module, 'sentinel')
+
+    for attr_name in attribute_call_counts:
+        mock_attribute = mock_attributes[attr_name]
+        assert (
+            mock_attribute.call_count ==
+            attribute_call_counts[attr_name]
+        )
+    assert mock_add.call_count == 1
+
+
+class TestBottleneckBlock(object):
+    """Tests for BottleneckBlock"""
+
+    def test_init(self):
+        """Test __init__
+
+        This tests a couple of things:
+        - The `torch.nn` operations used in the BottleneckBlock are set as
+          attributes on the object
+        - The `torch.nn` operations used in the BottleneckBlock are set as
+          expected (e.g. with the right number of filters and such)
+        """
+
+        test_cases = [
+            {'n_in_channels': 4, 'n_out_channels': 8,
+             'conv1_in_channels': 4, 'conv1_out_channels': 8,
+             'conv1_kernel_size': (1, 1), 'conv1_stride': (1, 1),
+             'conv1_bias': None, 'bn1_num_features': 8,
+             'conv2_in_channels': 8, 'conv2_out_channels': 8,
+             'conv2_kernel_size': (3, 3), 'conv2_stride': (1, 1),
+             'conv2_bias': None, 'bn2_num_features': 8,
+             'conv3_in_channels': 8, 'conv3_out_channels': 32,
+             'conv3_kernel_size': (1, 1), 'conv3_stride': (1, 1),
+             'conv3_bias': None, 'bn3_num_features': 32},
+            {'n_in_channels': 512, 'n_out_channels': 128,
+             'conv1_in_channels': 512, 'conv1_out_channels': 128,
+             'conv1_kernel_size': (1, 1), 'conv1_stride': (1, 1),
+             'conv1_bias': None, 'bn1_num_features': 128,
+             'conv2_in_channels': 128, 'conv2_out_channels': 128,
+             'conv2_kernel_size': (3, 3), 'conv2_stride': (1, 1),
+             'conv2_bias': None, 'bn2_num_features': 128,
+             'conv3_in_channels': 128, 'conv3_out_channels': 512,
+             'conv3_kernel_size': (1, 1), 'conv3_stride': (1, 1),
+             'conv3_bias': None, 'bn3_num_features': 512}
+        ]
+
+        conv_attributes = [
+            'in_channels', 'out_channels', 'kernel_size', 'stride', 'bias'
+        ]
+
+        for test_case in test_cases:
+            block = BottleneckBlock(
+                n_in_channels=test_case['n_in_channels'],
+                n_out_channels=test_case['n_out_channels']
+            )
+
+            for conv_name in ['conv1', 'conv2', 'conv3']:
+                conv = getattr(block, conv_name)
+                for conv_attr in conv_attributes:
+                    attr_value = getattr(conv, conv_attr)
+                    test_case_name = '{}_{}'.format(conv_name, conv_attr)
+                    assert attr_value == test_case[test_case_name]
+            for bn_name in ['bn1', 'bn2', 'bn3']:
+                bn = getattr(block, bn_name)
+                test_case_name = '{}_num_features'.format(bn_name)
+                assert bn.num_features == test_case[test_case_name]
+
+            assert block.relu is not None
+
+    def test_forward(self, monkeypatch):
+        """Test forward method
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        attribute_call_counts = {
+            'conv1': 1, 'bn1': 1, 'relu': 3,
+            'conv2': 1, 'bn2': 1, 'conv3': 1, 'bn3': 1
+        }
+        check_forward(BottleneckBlock, attribute_call_counts, monkeypatch)
+
+
+class TestProjectionShortcut(object):
+    """Tests for ProjectionShortcut"""
+
+    def test_init(self):
+        """Test __init__
+
+        This tests a couple of things:
+        - The `torch.nn` operations used in the ProjectionShortcut are set as
+          attributes on the object
+        - The `torch.nn` operations used in the ProjectionShortcut are set as
+          expected (e.g. with the right number of filters and such)
+        """
+
+        test_cases = [
+            {'n_in_channels': 4, 'n_out_channels': 8, 'stride': (1, 1),
+             'conv1_in_channels': 4, 'conv1_out_channels': 8,
+             'conv1_kernel_size': (1, 1), 'conv1_stride': (1, 1),
+             'conv1_bias': None, 'bn1_num_features': 8,
+             'conv2_in_channels': 8, 'conv2_out_channels': 8,
+             'conv2_kernel_size': (3, 3), 'conv2_stride': (1, 1),
+             'conv2_bias': None, 'bn2_num_features': 8,
+             'conv3_in_channels': 8, 'conv3_out_channels': 32,
+             'conv3_kernel_size': (1, 1), 'conv3_stride': (1, 1),
+             'conv3_bias': None, 'bn3_num_features': 32,
+             'projection_conv_in_channels': 4,
+             'projection_conv_out_channels': 32,
+             'projection_conv_kernel_size': (1, 1),
+             'projection_conv_stride': (1, 1), 'projection_conv_bias': None,
+             'projection_bn_num_features': 32},
+            {'n_in_channels': 512, 'n_out_channels': 128, 'stride': (2, 2),
+             'conv1_in_channels': 512, 'conv1_out_channels': 128,
+             'conv1_kernel_size': (1, 1), 'conv1_stride': (2, 2),
+             'conv1_bias': None, 'bn1_num_features': 128,
+             'conv2_in_channels': 128, 'conv2_out_channels': 128,
+             'conv2_kernel_size': (3, 3), 'conv2_stride': (1, 1),
+             'conv2_bias': None, 'bn2_num_features': 128,
+             'conv3_in_channels': 128, 'conv3_out_channels': 512,
+             'conv3_kernel_size': (1, 1), 'conv3_stride': (1, 1),
+             'conv3_bias': None, 'bn3_num_features': 512,
+             'projection_conv_in_channels': 512,
+             'projection_conv_out_channels': 512,
+             'projection_conv_kernel_size': (1, 1),
+             'projection_conv_stride': (2, 2), 'projection_conv_bias': None,
+             'projection_bn_num_features': 512}
+        ]
+
+        conv_attributes = [
+            'in_channels', 'out_channels', 'kernel_size', 'stride', 'bias'
+        ]
+
+        for test_case in test_cases:
+            block = ProjectionShortcut(
+                n_in_channels=test_case['n_in_channels'],
+                n_out_channels=test_case['n_out_channels'],
+                stride=test_case['stride']
+            )
+
+            for conv_name in ['conv1', 'conv2', 'conv3', 'projection_conv']:
+                conv = getattr(block, conv_name)
+                for conv_attr in conv_attributes:
+                    attr_value = getattr(conv, conv_attr)
+                    test_case_name = '{}_{}'.format(conv_name, conv_attr)
+                    assert attr_value == test_case[test_case_name]
+            for bn_name in ['bn1', 'bn2', 'bn3', 'projection_bn']:
+                bn = getattr(block, bn_name)
+                test_case_name = '{}_num_features'.format(bn_name)
+                assert bn.num_features == test_case[test_case_name]
+
+            assert block.relu is not None
+
+    def test_forward(self, monkeypatch):
+        """Test forward method
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        attribute_call_counts = {
+            'conv1': 1, 'bn1': 1, 'relu': 3,
+            'conv2': 1, 'bn2': 1, 'conv3': 1, 'bn3': 1,
+            'projection_conv': 1, 'projection_bn': 1
+        }
+        check_forward(ProjectionShortcut, attribute_call_counts, monkeypatch)
+
+
+class TestResNet(object):
+    """Tests for ResNet"""
+
+    def test_set_layers(self, monkeypatch):
+        """Test _set_layers
+
+        This tests a couple of things:
+        - The `torch.nn` operations used in the ResNet._set_layers are set as
+          attributes on the object
+        - The `torch.nn` operations used in the ResNet._set_layers are set as
+          expected (e.g. with the right number of filters and such)
+        """
+
+        test_cases = [
+            {'n_initial_channels': 4, 'n_blocks_per_stage': [2, 3],
+             'conv_in_channels': 3, 'conv_out_channels': 4,
+             'conv_kernel_size': (7, 7), 'conv_stride': (2, 2),
+             'conv_padding': (3, 3), 'conv_bias': True,
+             'bn_num_features': 4, 'max_pooling_kernel_size': (3, 3),
+             'max_pooling_stride': (2, 2), 'n_projection_shortcut_calls': 2,
+             'n_bottleneck_block_calls': 3, 'linear_in_features': 32},
+            {'n_initial_channels': 64, 'n_blocks_per_stage': [3, 4, 6, 3],
+             'conv_in_channels': 3, 'conv_out_channels': 64,
+             'conv_kernel_size': (7, 7), 'conv_stride': (2, 2),
+             'conv_padding': (3, 3), 'conv_bias': True,
+             'bn_num_features': 64, 'max_pooling_kernel_size': (3, 3),
+             'max_pooling_stride': (2, 2), 'n_projection_shortcut_calls': 4,
+             'n_bottleneck_block_calls': 12, 'linear_in_features': 2048}
+        ]
+
+        conv_attributes = [
+            'in_channels', 'out_channels', 'kernel_size', 'stride', 'bias',
+            'padding'
+        ]
+
+        mock_projection_shorcut = MagicMock()
+        mock_bottleneck_block = MagicMock()
+        monkeypatch.setattr(
+            ('networks.pytorch.object_classification.resnet'
+             '.ProjectionShortcut'),
+            mock_projection_shorcut
+        )
+        monkeypatch.setattr(
+            ('networks.pytorch.object_classification.resnet'
+             '.BottleneckBlock'),
+            mock_bottleneck_block
+        )
+
+        for test_case in test_cases:
+            resnet = MagicMock()
+            resnet.config = {
+                'n_initial_channels': test_case['n_initial_channels'],
+                'n_blocks_per_stage': test_case['n_blocks_per_stage']
+            }
+            resnet._set_layers = ResNet._set_layers
+            resnet._set_layers(self=resnet)
+
+            # check the conv, bn, max pooling, average pooling, and linear
+            # layers
+            conv = getattr(resnet, 'conv')
+            for conv_attr in conv_attributes:
+                attr_value = getattr(conv, conv_attr)
+                test_case_name = 'conv_{}'.format(conv_attr)
+                if 'bias' in test_case_name:
+                    assert attr_value is not None
+                else:
+                    assert attr_value == test_case[test_case_name]
+
+            bn = getattr(resnet, 'bn')
+            test_case_name = 'bn_num_features'
+            assert bn.num_features == test_case[test_case_name]
+
+            max_pooling = getattr(resnet, 'max_pooling')
+            for pooling_attr in ['kernel_size', 'stride']:
+                attr_value = getattr(max_pooling, pooling_attr)
+                test_case_name = 'max_pooling_{}'.format(pooling_attr)
+                assert attr_value == test_case[test_case_name]
+
+            assert resnet.relu is not None
+            assert resnet.average_pooling.kernel_size == (7, 7)
+            assert resnet.linear.in_features == test_case['linear_in_features']
+            assert resnet.linear.out_features == 1000
+
+            # check to make sure the correct number of residual stages are
+            # present, and that the consist of the correct blocks
+            assert (len(resnet.residual_stages) ==
+                    len(test_case['n_blocks_per_stage']))
+            for idx_stage, stage in enumerate(resnet.residual_stages):
+                assert len(stage) == test_case['n_blocks_per_stage'][idx_stage]
+            assert (mock_projection_shorcut.call_count ==
+                    test_case['n_projection_shortcut_calls'])
+            assert (mock_bottleneck_block.call_count ==
+                    test_case['n_bottleneck_block_calls'])
+
+            # reset the call count for the next iteration of the loop
+            mock_projection_shorcut.call_count = 0
+            mock_bottleneck_block.call_count = 0
+
+    def test_forward(self, monkeypatch):
+        """Test forward method
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        attribute_call_counts = {
+            'conv': 1, 'bn': 1, 'relu': 1, 'max_pooling': 1,
+            'average_pooling': 1, 'linear': 1
+        }
+
+        module = MagicMock()
+        module.residual_stages = [
+            [MagicMock(), MagicMock()],
+            [MagicMock(), MagicMock(), MagicMock()]
+        ]
+        mock_attributes = {}
+        for attr_name in attribute_call_counts:
+            mock_attribute = MagicMock()
+            setattr(module, attr_name, mock_attribute)
+            mock_attributes[attr_name] = mock_attribute
+
+        mock_add = MagicMock()
+        monkeypatch.setattr('torch.add', mock_add)
+
+        module.forward = ResNet.forward
+        module.forward(module, 'sentinel')
+
+        for attr_name in attribute_call_counts:
+            mock_attribute = mock_attributes[attr_name]
+            assert (
+                mock_attribute.call_count ==
+                attribute_call_counts[attr_name]
+            )
+        for mock_residual_stage in module.residual_stages:
+            for mock_residual_block in mock_residual_stage:
+                assert mock_residual_block.call_count == 1


### PR DESCRIPTION
This PR adds a PyTorch Resnet implementation, based off the [original paper](https://arxiv.org/abs/1512.03385). It should be able to support a number of ResNet variations (i.e. ResNet 50, ResNet101), although doesn't yet support versions of ResNet that are post the original paper (e.g. those from the [Identity Mappings](https://arxiv.org/abs/1603.05027) paper). In a follow-up PR, YML config files will be added that allow for training these resnets.