### PR TITLE
Add ResNet configs

### DIFF
--- a/dl_playground/networks/pytorch/object_classification/resnet.py
+++ b/dl_playground/networks/pytorch/object_classification/resnet.py
@@ -22,7 +22,7 @@ implementation is extremely close).
 
 import torch
 from torch.nn import (
-    AvgPool2d, BatchNorm2d, Conv2d, Linear, MaxPool2d, Module, ReLU
+    AvgPool2d, BatchNorm2d, Conv2d, Linear, MaxPool2d, Module, ModuleList, ReLU
 )
 
 from utils.generic_utils import validate_config
@@ -175,7 +175,7 @@ class ProjectionShortcut(Module):
         return layer
 
 
-class ResNet(object):
+class ResNet(Module):
     """ResNet network"""
 
     required_config_keys = {
@@ -231,10 +231,10 @@ class ResNet(object):
         self.relu = ReLU()
         self.max_pooling = MaxPool2d(kernel_size=(3, 3), stride=(2, 2))
 
-        self.residual_stages = []
+        self.residual_stages = ModuleList()
         n_out_channels = n_initial_channels
         for idx_stage, n_blocks in enumerate(n_blocks_per_stage):
-            stage_blocks = []
+            stage_blocks = ModuleList()
 
             # Each residual block ends with a conv using 4x the number of
             # n_out_channels, which requires us to adjust n_in_channels to

--- a/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
@@ -31,11 +31,11 @@ dataset:
                 value:
                     - 'image'
     train_loading_params:
-        batch_size: 128
+        batch_size: 32
         shuffle: True
         n_workers: 4
     validation_loading_params:
-        batch_size: 128
+        batch_size: 32
         shuffle: False
         n_workers: 2
 network:
@@ -52,7 +52,7 @@ trainer:
         config:
             optimizer: 'adam'
             loss: 'categorical_crossentropy'
-            batch_size: 128
+            batch_size: 32
             n_epochs: 10
     callbacks:
         - tensorflow.keras.callbacks.CSVLogger

--- a/dl_playground/training/training_configs/resnet101_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/resnet101_imagenet_pytorch.yml
@@ -49,11 +49,13 @@ dataset:
         shuffle: False
         num_workers: 2
 network:
-    importpath: networks.pytorch.object_classification.alexnet.AlexNet
+    importpath: networks.pytorch.object_classification.resnet.ResNet
     init_params:
         config:
             n_channels: 3
             n_classes: 1000
+            n_initial_channels: 64
+            n_blocks_per_stage: [3, 4, 23, 3]
 trainer:
     importpath: training.pytorch.imagenet_trainer.ImageNetTrainer
     init_params:

--- a/dl_playground/training/training_configs/resnet152_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/resnet152_imagenet_pytorch.yml
@@ -49,11 +49,13 @@ dataset:
         shuffle: False
         num_workers: 2
 network:
-    importpath: networks.pytorch.object_classification.alexnet.AlexNet
+    importpath: networks.pytorch.object_classification.resnet.ResNet
     init_params:
         config:
             n_channels: 3
             n_classes: 1000
+            n_initial_channels: 64
+            n_blocks_per_stage: [3, 8, 36, 3]
 trainer:
     importpath: training.pytorch.imagenet_trainer.ImageNetTrainer
     init_params:

--- a/dl_playground/training/training_configs/resnet50_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/resnet50_imagenet_pytorch.yml
@@ -49,11 +49,13 @@ dataset:
         shuffle: False
         num_workers: 2
 network:
-    importpath: networks.pytorch.object_classification.alexnet.AlexNet
+    importpath: networks.pytorch.object_classification.resnet.ResNet
     init_params:
         config:
             n_channels: 3
             n_classes: 1000
+            n_initial_channels: 64
+            n_blocks_per_stage: [3, 4, 6, 3]
 trainer:
     importpath: training.pytorch.imagenet_trainer.ImageNetTrainer
     init_params:

--- a/tests/integration_tests/networks/pytorch/object_classification/test_resnet.py
+++ b/tests/integration_tests/networks/pytorch/object_classification/test_resnet.py
@@ -1,0 +1,41 @@
+"""Integration tests for networks.pytorch.object_classification.resnet"""
+
+from networks.pytorch.object_classification.resnet import ResNet
+
+
+class TestResNet(object):
+    """Tests for ResNet"""
+
+    def test_init(self):
+        """Test __init__
+
+        This simply tests that an instantiated ResNet has the expected number
+        of parameter objects returned from its `parameters()`. This is more or
+        less a check simply to make sure that all of the BottleNeck and
+        ProjectionShortcut modules parameters are included in the ResNet
+        itself.
+
+        The following parameters are expected:
+        - From the ResNet itself (excluding BottleneckBlock or
+          ProjectionShortcut objects): 6 (2 for conv1 plus bias, 2 for bn plus
+          bias, 2 for final linear layer plus bias)
+        - From each BottleneckBlock: 9
+        - From each ProjectionShortcut: 12
+        """
+
+        test_cases = [
+            {'n_initial_channels': 64, 'n_blocks_per_stage': [3, 4, 6, 3],
+             'n_expected_objects': 162},
+            {'n_initial_channels': 64, 'n_blocks_per_stage': [3, 4],
+             'n_expected_objects': 75},
+            {'n_initial_channels': 64, 'n_blocks_per_stage': [3, 4, 23, 3],
+             'n_expected_objects': 315}
+        ]
+
+        for test_case in test_cases:
+            n_expected_objects = test_case.pop('n_expected_objects')
+            test_case['n_channels'] = 3
+            test_case['n_classes'] = 1000
+
+            resnet = ResNet(test_case)
+            assert len(list(resnet.parameters())) == n_expected_objects

--- a/tests/integration_tests/training/pytorch/test_training_job.py
+++ b/tests/integration_tests/training/pytorch/test_training_job.py
@@ -96,7 +96,7 @@ class TestPyTorchTrainingJob(object):
         assert isinstance(trainer, ImageNetTrainer)
         assert trainer.optimizer == 'Adam'
         assert trainer.loss == 'CrossEntropyLoss'
-        assert trainer.batch_size == 128
+        assert trainer.batch_size == 32
         assert trainer.n_epochs == 10
         assert trainer.device == torch.device('cuda:0')
 

--- a/tests/integration_tests/training/tf/test_training_job.py
+++ b/tests/integration_tests/training/tf/test_training_job.py
@@ -95,7 +95,7 @@ class TestTFTrainingJob(object):
         assert isinstance(trainer, ImageNetTrainer)
         assert trainer.optimizer == 'adam'
         assert trainer.loss == 'categorical_crossentropy'
-        assert trainer.batch_size == 128
+        assert trainer.batch_size == 32
         assert trainer.n_epochs == 10
 
     def test_parse_transformations(self, config):


### PR DESCRIPTION
This PR does a couple of things:

1. Adds YML configs for `ResNet50`, `ResNet101`, and `ResNet152` using the newly added pytorch implementation.
2. Updates the `ResNet` network itself to correctly include the `BottleneckBlock` and `ProjectionShortcut` modules (before there was missing use of a `ModuleList` in a couple of places). 
3. Updates the tests for recent changes, and adds two new ones to account for recent changes and improve coverage. 