### PR TITLE
TensorBoard callback for PyTorch

### DIFF
--- a/dl_playground/datasets/imagenet_dataset.py
+++ b/dl_playground/datasets/imagenet_dataset.py
@@ -48,6 +48,11 @@ class ImageNetDataSet(Dataset):
     def __getitem__(self, idx):
         """Return the image, label pair at index `idx` from `self.df_obs`
 
+        Occasionally (< 1e-4% of the time), one of the loaded images has either
+        2 channels or 4 channels. If the former, the image is simply stacked
+        three times to create a 3 channel input, and if the latter, the first
+        three channels of the four are taken.
+
         :return: dict with keys:
         - numpy.ndarray image: pixel data loaded from the `fpath_image` at
           index `idx` of `self.df_obs`
@@ -62,6 +67,9 @@ class ImageNetDataSet(Dataset):
             image = np.concatenate((image, image, image), axis=-1)
 
         n_channels = image.shape[-1]
+        if n_channels == 4:
+            n_channels = 3
+            image = image[:, :, :3]
         target_shape = (
             self.config['height'], self.config['width'], n_channels
         )

--- a/dl_playground/training/pytorch/callbacks.py
+++ b/dl_playground/training/pytorch/callbacks.py
@@ -1,0 +1,80 @@
+"""Callbacks for training with PyTorch
+
+Reference Implementation in:
+    - https://github.com/keras-team/keras/blob/master/keras/callbacks.py
+"""
+
+
+from tensorboard.compat.proto.summary_pb2 import Summary
+from tensorflow.python.keras.callbacks import Callback
+from torch.utils.tensorboard.writer import FileWriter
+
+
+class TensorBoard(Callback):
+    """Tensorboard basic visualizations
+
+    Reference Implementation in:
+        - https://github.com/keras-team/keras/blob/master/keras/callbacks.py
+    """
+
+    def __init__(self, log_dir='./logs', update_freq='batch'):
+        """Init
+
+        :param log_dir: the directory path to save the log files for
+         TensorBoard to parse
+        :type log_dir: str
+        :param update_freq: how often to write loss and metrics, one of 'epoch'
+         or 'batch'
+        :type update_freq: str
+        """
+
+        super().__init__()
+
+        self.update_freq = update_freq
+        self.writer = FileWriter(logdir=log_dir)
+        self.samples_seen = 0
+
+    def _write_logs(self, logs, index):
+        """Write log values to the log files
+
+        :param logs:
+        :type logs:
+        :param index:
+        :type index:
+        """
+
+        for name, value in logs.items():
+            if name in ['batch', 'size']:
+                continue
+            summary = Summary(
+                value=[Summary.Value(tag=name, simple_value=value)]
+            )
+            self.writer.add_summary(summary, index)
+        self.writer.flush()
+
+    def on_batch_end(self, batch, logs=None):
+        """Save loss and metric statistics for the most recent batch
+
+        :param batch: index of the most recent batch
+        :type batch: int
+        :param logs: holds the loss and metric values computed on the most
+         recent batch
+        :type logs: dict
+        """
+
+        if self.update_freq == 'batch':
+            self.samples_seen += logs['size']
+            self._write_logs(logs, self.samples_seen)
+
+    def on_epoch_end(self, epoch, logs=None):
+        """Save loss and metric statistics for the most recent epoch
+
+        :param epoch: index of the most recent epoch
+        :type epoch: int
+        :param logs: holds the loss and metric values computed on the most
+         recent epoch
+        :type logs: dict
+        """
+
+        if self.update_freq == 'epoch':
+            self._write_logs(logs, epoch)

--- a/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
+++ b/dl_playground/training/training_configs/alexnet_imagenet_tf.yml
@@ -56,5 +56,6 @@ trainer:
             n_epochs: 10
     callbacks:
         - tensorflow.keras.callbacks.CSVLogger
+        - tensorflow.keras.callbacks.TensorBoard
     metrics:
         - tensorflow.keras.metrics.categorical_accuracy

--- a/dl_playground/training/training_configs/resnet50_imagenet_pytorch.yml
+++ b/dl_playground/training/training_configs/resnet50_imagenet_pytorch.yml
@@ -43,11 +43,11 @@ dataset:
     train_loading_params:
         batch_size: 32
         shuffle: True
-        num_workers: 4
+        num_workers: 16
     validation_loading_params:
         batch_size: 32
         shuffle: False
-        num_workers: 2
+        num_workers: 16
 network:
     importpath: networks.pytorch.object_classification.resnet.ResNet
     init_params:
@@ -58,6 +58,12 @@ network:
             n_blocks_per_stage: [3, 4, 6, 3]
 trainer:
     importpath: training.pytorch.imagenet_trainer.ImageNetTrainer
+    callbacks: 
+        - training.pytorch.callbacks.TensorBoard
+        - tensorflow.keras.callbacks.CSVLogger
+        - tensorflow.keras.callbacks.ModelCheckpoint:
+                monitor: val_loss
+                save_best_only: True
     init_params:
         config:
             optimizer: 'Adam'

--- a/dl_playground/training/training_job.py
+++ b/dl_playground/training/training_job.py
@@ -141,6 +141,15 @@ class TrainingJob(object):
                 callback_params['filename'] = os.path.join(
                     self.dirpath_job, 'history.csv'
                 )
+            elif 'TensorBoard' in callback_importpath:
+                callback_params['log_dir'] = os.path.join(
+                    self.dirpath_job, 'tensorboard'
+                )
+            elif 'ModelCheckpoint' in callback_importpath:
+                callback_params['filepath'] = os.path.join(
+                    self.dirpath_job, 'weights'
+                )
+                callback_params['save_weights_only'] = True
 
             Callback = import_object(callback_importpath)
             callback = Callback(**callback_params)

--- a/dl_playground/utils/test_utils.py
+++ b/dl_playground/utils/test_utils.py
@@ -28,10 +28,14 @@ def df_images():
     rows = []
     for idx in range(3):
         height, width = np.random.randint(128, 600, 2)
-        num_channels = np.random.choice((1, 3), 1).tolist()[0]
+        num_channels = np.random.choice((1, 4), 1).tolist()[0]
 
         input_image = np.random.random((height, width, num_channels))
-        fpath_image = os.path.join(tempdir.name, '{}.jpg'.format(idx))
+        fpath_image = os.path.join(tempdir.name, '{}'.format(idx))
+        if num_channels <= 3:
+            fpath_image += '.jpg'
+        else:
+            fpath_image += '.tif'
         imageio.imwrite(fpath_image, input_image)
 
         rows.append({

--- a/setup/environment_cpu.yml
+++ b/setup/environment_cpu.yml
@@ -29,6 +29,7 @@ dependencies:
   - expat=2.2.6=he6710b0_0
   - fontconfig=2.13.0=h9420a91_0
   - freetype=2.9.1=h8a8886c_1
+  - future=0.17.1=py37_0
   - gast=0.2.2=py37_0
   - glib=2.56.2=hd408876_0
   - gmp=6.1.2=h6c8ec71_1
@@ -161,3 +162,5 @@ dependencies:
   - zeromq=4.3.1=he6710b0_3
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
+  - pip:
+      - tb-nightly==1.14.0a20190523

--- a/setup/environment_gpu.yml
+++ b/setup/environment_gpu.yml
@@ -32,6 +32,7 @@ dependencies:
   - expat=2.2.6=he6710b0_0
   - fontconfig=2.13.0=h9420a91_0
   - freetype=2.9.1=h8a8886c_1
+  - future=0.17.1=py37_0
   - gast=0.2.2=py37_0
   - glib=2.56.2=hd408876_0
   - gmp=6.1.2=h6c8ec71_1
@@ -165,3 +166,5 @@ dependencies:
   - zeromq=4.3.1=he6710b0_3
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
+  - pip:
+    - tb-nightly==1.14.0a20190523

--- a/tests/unit_tests/datasets/test_imagenet_dataset.py
+++ b/tests/unit_tests/datasets/test_imagenet_dataset.py
@@ -116,6 +116,9 @@ class TestImageNetDataSet(object):
                 assert np.array_equal(
                     sample_image[..., 1], sample_image[..., 2]
                 )
+            elif image.shape[-1] == 4:
+                sample_image = sample['image']
+                assert sample_image.shape[-1] == 3
 
         with pytest.raises(KeyError):
             imagenet_dataset[4]

--- a/tests/unit_tests/training/pytorch/test_callbacks.py
+++ b/tests/unit_tests/training/pytorch/test_callbacks.py
@@ -1,0 +1,193 @@
+"""Tests for training.pytorch.callbacks"""
+
+from unittest.mock import call, MagicMock
+
+import pytest
+
+from torch.utils.tensorboard.writer import FileWriter
+from training.pytorch.callbacks import TensorBoard
+
+
+class TestTensorBoard(object):
+    """Test for TensorBoard"""
+
+    @pytest.fixture(scope='class')
+    def mock_logs(self):
+        """mock_logs object fixture"""
+
+        return {
+            'name1': 1, 'name2': 2,
+            'batch': 5, 'size': 32
+        }
+
+    def test_init(self, monkeypatch):
+        """Test __init__
+
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        mock_init = MagicMock()
+        monkeypatch.setattr(
+            'training.pytorch.callbacks.Callback.__init__', mock_init
+        )
+
+        mock_file_writer = MagicMock()
+        mock_file_writer.return_value = None
+        monkeypatch.setattr(
+            'training.pytorch.callbacks.FileWriter.__init__', mock_file_writer
+        )
+
+        test_cases = [
+            {},
+            {'update_freq': 'epoch'},
+            {'log_dir': 'training_jobs/test_job', 'update_freq': 'epoch'}
+        ]
+
+        for test_case in test_cases:
+            tensorboard = TensorBoard(**test_case)
+
+            if 'update_freq' in test_case:
+                assert tensorboard.update_freq == test_case['update_freq']
+            else:
+                assert tensorboard.update_freq == 'batch'
+
+            if 'log_dir' in test_case:
+                mock_file_writer.assert_called_once_with(
+                    logdir=test_case['log_dir']
+                )
+            else:
+                mock_file_writer.assert_called_once_with(
+                    logdir='./logs'
+                )
+
+            mock_init.assert_called_once_with()
+            assert tensorboard.samples_seen == 0
+            mock_init.reset_mock()
+            mock_file_writer.reset_mock()
+
+    def test_write_logs(self, mock_logs, monkeypatch):
+        """Test _write_logs
+
+        :param mock_logs: mock_logs object fixture
+        :type mock_logs: dict
+        :param monkeypatch: monkeypatch object
+        :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        """
+
+        # mock Summary.__init__ to control the return value and ensure that
+        # `TensorBoard.writer.add_summary` is called with the return value
+        mock_summary = MagicMock()
+        mock_summary.return_value = 'mock_summary_return'
+        monkeypatch.setattr(
+            'training.pytorch.callbacks.Summary', mock_summary
+        )
+
+        mock_value = MagicMock()
+        mock_value.return_value = 'mock_value_return'
+        monkeypatch.setattr(
+            'training.pytorch.callbacks.Summary.Value', mock_value
+        )
+
+        mock_logs = {
+            'name1': 1, 'name2': 2,
+            'batch': 5, 'size': 32
+        }
+
+        test_cases = [
+            {'logs': mock_logs, 'index': 2},
+            {'logs': mock_logs, 'index': 5}
+        ]
+
+        for test_case in test_cases:
+            tensorboard = MagicMock()
+            tensorboard.writer = MagicMock(spec=FileWriter)
+            tensorboard._write_logs = TensorBoard._write_logs
+
+            tensorboard._write_logs(self=tensorboard, **test_case)
+
+            mock_value.assert_has_calls([
+                call(tag='name1', simple_value=1),
+                call(tag='name2', simple_value=2),
+            ], any_order=True)
+            mock_summary.assert_has_calls([
+                call(value=['mock_value_return']),
+                call(value=['mock_value_return'])
+            ], any_order=True)
+            tensorboard.writer.add_summary.assert_has_calls([
+                call('mock_summary_return', test_case['index']),
+            ])
+            tensorboard.writer.flush.assert_called_once()
+
+            mock_summary.reset_mock()
+            mock_value.reset_mock()
+            tensorboard.writer.reset_mock()
+
+    def test_on_batch_end(self, mock_logs):
+        """Test on_batch_end
+
+        :param mock_logs: mock_logs object fixture
+        :type mock_logs: dict
+        """
+
+        tensorboard = MagicMock()
+        tensorboard.update_freq = 'batch'
+        tensorboard.samples_seen = 0
+        mock_write_logs = MagicMock()
+        tensorboard._write_logs = mock_write_logs
+
+        tensorboard.on_batch_end = TensorBoard.on_batch_end
+
+        tensorboard.on_batch_end(
+            self=tensorboard, batch=1, logs=mock_logs
+        )
+        assert tensorboard.samples_seen == 32
+
+        tensorboard.on_batch_end(
+            self=tensorboard, batch=2, logs=mock_logs
+        )
+        assert tensorboard.samples_seen == 64
+
+        tensorboard.update_freq = 'epoch'
+        tensorboard.on_batch_end(
+            self=tensorboard, batch=0, logs=mock_logs
+        )
+        assert tensorboard.samples_seen == 64
+
+        mock_write_logs.assert_has_calls([
+            call(mock_logs, 32), call(mock_logs, 64)
+        ])
+
+    def test_on_epoch_end(self, mock_logs):
+        """Test on_epoch_end
+
+        :param mock_logs: mock_logs object fixture
+        :type mock_logs: dict
+        """
+
+        tensorboard = MagicMock()
+        tensorboard.update_freq = 'epoch'
+        mock_write_logs = MagicMock()
+        tensorboard._write_logs = mock_write_logs
+
+        tensorboard.on_epoch_end = TensorBoard.on_epoch_end
+
+        tensorboard.on_epoch_end(
+            self=tensorboard, epoch=0, logs=mock_logs
+        )
+        assert mock_write_logs.call_count == 1
+
+        tensorboard.on_epoch_end(
+            self=tensorboard, epoch=1, logs=mock_logs
+        )
+        assert mock_write_logs.call_count == 2
+
+        tensorboard.update_freq = 'batch'
+        tensorboard.on_epoch_end(
+            self=tensorboard, epoch=2, logs=mock_logs
+        )
+        assert mock_write_logs.call_count == 2
+
+        mock_write_logs.assert_has_calls([
+            call(mock_logs, 0), call(mock_logs, 1)
+        ])


### PR DESCRIPTION
This PR does a couple of things:

1. Adds a `TensorBoard` callback for PyTorch training, based off the recent addition of support for this in [PyTorch](https://pytorch.org/docs/stable/tensorboard.html). It also adds tests for this.
2. Updates the `_parse_callbacks` method on the `TrainingJob` class to allow for using the `ModelCheckpoint` callback more easily. There will be a few more updates coming to this in the future, too.
3. Updates the `evaluate_generator` method on the `pytorch.model.Model` class to correctly calculate the returned values. Before the calculation was diving by the total number of observations, and when it should have been the number of batches. It's been re-worked to circumvent that and also allow for different sized batches, too. Tests have been updated for these changes.